### PR TITLE
#166240819 enable user email verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "passport-twitter": "^1.0.4",
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
-    "joi": "^14.3.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",

--- a/src/api/controllers/authController.js
+++ b/src/api/controllers/authController.js
@@ -7,6 +7,7 @@ import status from '../../helpers/constants/status.codes';
 import env from '../../configs/environments';
 import sendError from '../../helpers/error.sender';
 import errors from '../../helpers/constants/error.messages';
+import mailer from '../../helpers/Mailer/index';
 
 const { User } = models;
 /**
@@ -33,6 +34,14 @@ export default class Auth {
       username,
       email,
       password: hashedPassword
+    });
+    await mailer('Please verify your email', 'Email verification', email, 'notifications', {
+      email,
+      buttonText: 'Verify',
+      userName: username,
+      message: "Please click on the link to verify your email for authors haven.If you didn't request this, simply ignore this e-mail.",
+      link: `${env.baseUrl}/users/verifyEmail`
+
     });
     const tokenData = { id: user.dataValues.id, username, email };
     const token = generateToken(tokenData, env.secret);

--- a/src/api/controllers/verifyEmail.js
+++ b/src/api/controllers/verifyEmail.js
@@ -1,0 +1,38 @@
+import decodejwt from '../../helpers/tokens/decode.token';
+import status from '../../helpers/constants/status.codes';
+import models from '../models/index';
+import error from '../../helpers/error.sender';
+import errorMessages from '../../helpers/constants/error.messages';
+/**
+ * @class
+ */
+export default class {
+  /**
+     * @description verification link controller
+     * @param {*} req
+     * @param {*} res
+     * @returns {*} void
+     */
+  static async verifyEmail(req, res) {
+    const { token } = req.params;
+    const result = decodejwt(token);
+    if (result !== undefined) {
+      const action = await models.User.update({ verified: true }, {
+        where: {
+          email: result.user.email,
+        }
+      });
+      const ZERO = 0;
+      if (!action.includes(ZERO)) {
+        res.status(status.OK).json({
+          status: 200,
+          message: 'Your email is successfully verified'
+        });
+      } else {
+        error(status.NOT_FOUND, res, 'user', errorMessages.noUser);
+      }
+    } else {
+      error(status.BAD_REQUEST, res, 'link', errorMessages.emailLinkInvalid);
+    }
+  }
+}

--- a/src/api/routes/authRouter.js
+++ b/src/api/routes/authRouter.js
@@ -6,6 +6,7 @@ import validateToken from '../../middlewares/checkValidToken';
 import socialAuthController from '../controllers/socialAuth';
 import passport from '../../configs/passport';
 import social from '../../middlewares/social/social';
+import EmailVerifier from '../controllers/verifyEmail';
 
 const authRouter = new Router();
 
@@ -31,5 +32,6 @@ authRouter.get('/twitter', passport.authenticate('twitter', { scope: ['email', '
 authRouter.get('/twitter/callback',
   passport.authenticate('twitter'),
   socialAuthController.twitterAuth);
+authRouter.get('/verifyEmail/:token', EmailVerifier.verifyEmail);
 
 export default authRouter;

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "version": "1.0.0",
     "title": "Authors Heaven",
-    "description": "Authors Heaven Appi Documentation",
+    "description": "usersors Heaven Appi Documentation",
     "license": {
       "name": "MIT",
       "url": "https://opensource.org/licenses/MIT"
@@ -295,19 +295,70 @@
         }
       }
     },
-    "resetPassword": {
-      "type": "object",
-      "properties": {
-        "email": {
-          "type": "string"
+    "/users/verifyEmail": {
+      "get": {
+        "tags": ["Users"],
+        "summary": "Verify user's email",
+        "description": "",
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token",
+            "description": "",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Your email is successfully verified"
+          },
+          "400": {
+            "description": "The link provided is  corrupt, please request a new one or try to click it again"
+          },
+          "404": {
+            "description": "User doesn't exist."
+          },
+          "default": {
+            "description": "Something went wrong"
+          }
         }
       }
     },
-    "updatePassword": {
-      "type": "object",
-      "properties": {
-        "email": {
-          "type": "string"
+    "externalDocs": {
+      "description": "Find out more about Swagger",
+      "url": "http://swagger.io"
+    },
+    "definitions": {
+      "signup": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
+        }
+      },
+      "resetPassword": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          }
+        }
+      },
+      "updatePassword": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          }
         }
       }
     }

--- a/src/helpers/constants/error.messages.js
+++ b/src/helpers/constants/error.messages.js
@@ -5,5 +5,7 @@ export default {
   emptyBody: 'Server unable to process the recieved data',
   unkownEmail: "A user with the provided email doesn't exist",
   invalidLink: 'Invalid link provided',
-  incorectPassword: 'Incorect password provided'
+  incorectPassword: 'Incorect password provided',
+  emailLinkInvalid: 'The link provided is  corrupt, please request a new one or try to click it again',
+  noUser: "User doesn't exist."
 };

--- a/tests/verify.test.js
+++ b/tests/verify.test.js
@@ -1,0 +1,90 @@
+import chai from 'chai';
+import chaihttp from 'chai-http';
+import createToken from '../src/helpers/tokens/generate.token';
+import env from '../src/configs/environments';
+import server from '../src/index';
+import status from '../src/helpers/constants/status.codes';
+import errorMessages from '../src/helpers/constants/error.messages';
+
+
+chai.use(chaihttp);
+chai.should();
+
+
+describe('GET /verifyEmail', () => {
+  it('Should return a success message if the link is valid', (done) => {
+    const user = {
+      username: 'BurindiAlain',
+      email: 'alain@gmail.com',
+      password: 'password23423',
+      confirmPassword: 'password23423'
+    };
+
+    const { username, email } = user;
+
+    const verifytoken = createToken({ username, email }, env.secret);
+    chai
+      .request(server)
+      .get(`/api/users/verifyEmail/${verifytoken}`)
+      .end(async (err, res) => {
+        await res.should.have.status(status.OK);
+        await res.body.message.should.be.eq('Your email is successfully verified');
+        done();
+      });
+  });
+
+  it('Should return a message if a user doesn\'t exist', (done) => {
+    const user = {
+      username: 'BurindiAlain',
+      email: 'alain@gmail.com',
+      password: 'password23423',
+      confirmPassword: 'password23423'
+    };
+    chai
+      .request(server)
+      .post('/api/users/signup')
+      .send(user)
+      .end();
+
+    const { username } = user;
+
+    const verifytoken = createToken({ username, email: 'dummy@email.com' }, env.secret);
+
+    chai
+      .request(server)
+      .get(`/api/users/verifyEmail/${verifytoken}`)
+      .end((err, res) => {
+        res.should.have.status(status.NOT_FOUND);
+        res.body.errors.user.should.be.eq(errorMessages.noUser);
+        done();
+      });
+  });
+
+  it('Should respond with a message if the token is invalid', (done) => {
+    const user = {
+      username: 'BurindiAlain',
+      email: 'alain@gmail.com',
+      password: 'password23423',
+      confirmPassword: 'password23423'
+    };
+
+    chai
+      .request(server)
+      .post('/api/users/signup')
+      .send(user)
+      .end();
+
+    const { username } = user;
+
+    const verifytoken = createToken({ username }, 'env.secret');
+
+    chai
+      .request(server)
+      .get(`/api/users/verifyEmail/${verifytoken}`)
+      .end((err, res) => {
+        res.should.have.status(status.BAD_REQUEST);
+        res.body.errors.link.should.be.eq(errorMessages.emailLinkInvalid);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
 * Enable the user to verify email.
#### Description of Task to be completed?
 * After successful registration, an email is sent to the user's personal email provider.
 * Once the user receives the email with the verification link and clicks it, the user is redirected to the ``/users/verifyEmail`` endpoint to verify the user.
#### How should this be manually tested?
* Clone the repo to  local machine.
* Run ``npm install``   to install the dependencies.
* Set up the   ``.env`` as instructed by the   ``.env-example``
* Run  ``npm  start``.
* Post registration data to  ``/api/users/signup``   and check your email (check the spam).
*  Click the verification link.
#### What are the relevant pivotal tracker stories?
#[166240819](https://www.pivotaltracker.com/story/show/166240819)
#### Screenshots (if appropriate)
<img width="1440" alt="Screen Shot 2019-06-13 at 18 07 18" src="https://user-images.githubusercontent.com/37019531/59452872-fa356380-8e0e-11e9-9343-d00ccbc17f35.png">
<img width="1440" alt="Screen Shot 2019-06-13 at 19 04 11" src="https://user-images.githubusercontent.com/37019531/59452896-08837f80-8e0f-11e9-81c7-51d7a36010b9.png">
<img width="1440" alt="Screen Shot 2019-06-13 at 19 04 47" src="https://user-images.githubusercontent.com/37019531/59453023-4a142a80-8e0f-11e9-9986-2a5bed9471c8.png">

