### PR TITLE
#[166240839] Users should be able to share articles across different channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",
+    "open": "^6.4.0",
     "passport": "^0.4.0",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth": "^2.0.0",

--- a/src/api/controllers/articleController.js
+++ b/src/api/controllers/articleController.js
@@ -7,7 +7,7 @@ import errorSender from '../../helpers/error.sender';
 import generatePagination from '../../helpers/generate.pagination.details';
 
 const {
-  Article, Category, User, Report, Highlight
+  Article, Category, User, Report, Share, Highlight
 } = models;
 
 const { CREATED, BAD_REQUEST } = statusCodes;
@@ -239,8 +239,8 @@ export default class ArticleController {
         'Sorry, but that reason does not exist, Thanks');
     }
   }
-  
-  /*
+
+  /**
   * allow a user to highlight a text in an article
   *
   * @author Alain Burindi
@@ -269,5 +269,35 @@ export default class ArticleController {
     } else {
       errorSender(BAD_REQUEST, res, 'text', errorMessage.textMatch);
     }
+  }
+
+  /**
+   * allow an author to report a certain article as inappropriate
+   *
+   * @author Frank Mutabazi
+   * allow a user to share an article on social media
+   *
+   * @static
+   * @param {object} req the request
+   * @param {object} res the response to be sent
+   * @memberof ArticleController
+   * @returns {Object} res
+   */
+  static async socialShareArticle(req, res) {
+    const { user: { id } } = req.user;
+    const { slug } = req.params;
+    const { sharedOn } = req;
+    const { title } = req;
+
+    await Share.create({
+      userId: id,
+      articleSlug: slug,
+      sharedOn
+    });
+
+    return res.status(statusCodes.CREATED).json({
+      status: statusCodes.CREATED,
+      message: `${title} has been shared successfully on ${sharedOn}, Thanks`
+    });
   }
 }

--- a/src/api/migrations/20190704140437-create-share.js
+++ b/src/api/migrations/20190704140437-create-share.js
@@ -1,0 +1,49 @@
+
+export default {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Shares', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false,
+        unique: false
+      },
+      articleSlug: {
+        type: Sequelize.STRING,
+        references: {
+          model: 'Articles',
+          key: 'slug'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false,
+        unique: false
+      },
+      sharedOn: {
+        type: Sequelize.STRING
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    })
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Shares');
+  }
+};

--- a/src/api/models/index.js
+++ b/src/api/models/index.js
@@ -13,6 +13,7 @@ const models = {
   Rating: sequelize.import('./rating'),
   Report: sequelize.import('./report'),
   Reason: sequelize.import('./reasons'),
+  Share: sequelize.import('./share'),
   Highlight: sequelize.import('./highlight'),
   Following: sequelize.import('./following')
 };

--- a/src/api/models/share.js
+++ b/src/api/models/share.js
@@ -1,0 +1,33 @@
+export default (sequelize, DataTypes) => {
+  const Share = sequelize.define('Share', {
+    userId: 
+    { 
+      type: DataTypes.INTEGER,
+      onDelete: 'CASCADE',
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      }
+    },
+    articleSlug: {
+      type: DataTypes.STRING,
+      onDelete: 'CASCADE',
+      allowNull: false,
+      references: {
+        model: 'Articles',
+        key: 'slug'
+      }
+    } ,
+    sharedOn: {
+      type: DataTypes.STRING,
+      onDelete: 'CASCADE',
+      allowNull: false
+    }
+  }, {});
+  Share.associate = ({ User, Article }) => {
+    Share.belongsTo(User, { foreignKey: 'userId'});
+    Share.belongsTo(Article, { foreignKey: 'articleSlug'});
+  };
+  return Share;
+};

--- a/src/api/routes/articleRouter.js
+++ b/src/api/routes/articleRouter.js
@@ -9,6 +9,7 @@ import checkArticleOwner from '../../middlewares/checkArticleOwnership';
 import checkExistingRates from '../../middlewares/checkExistingRating';
 import uploadImage from '../../middlewares/upload';
 import errorHandler from '../../middlewares/errorHandler';
+import shareArticle from '../../middlewares/shareArticle';
 import validateRatingsRoute from '../../middlewares/validations/ratings.routes';
 
 const articleRouter = new Router();
@@ -61,5 +62,30 @@ articleRouter.post('/:slug/report',
   validateInputs('reportArticle', ['reason']),
   checkArticleOwner.checkOwner,
   articleController.reportAnArticle);
+
+articleRouter.post('/:slug/share/facebook',
+  checkValidToken,
+  checkArticle.getArticle,
+  shareArticle,
+  articleController.socialShareArticle);
+
+articleRouter.post('/:slug/share/twitter',
+  checkValidToken,
+  checkArticle.getArticle,
+  shareArticle,
+  articleController.socialShareArticle);
+
+articleRouter.post('/:slug/share/linkedin',
+  checkValidToken,
+  checkArticle.getArticle,
+  shareArticle,
+  articleController.socialShareArticle);
+
+articleRouter.post('/:slug/share/gmail',
+  checkValidToken,
+  checkArticle.getArticle,
+  shareArticle,
+  articleController.socialShareArticle);
+
 
 export default articleRouter;

--- a/src/configs/environments.js
+++ b/src/configs/environments.js
@@ -15,6 +15,7 @@ const testDatabase = process.env.TEST_DATABASE;
 const host = process.env.HOST;
 const dialect = 'postgres';
 const port = process.env.DB_PORT;
+const { APP_URL_FRONTEND } = process.env;
 
 const environments = [
   {
@@ -31,7 +32,8 @@ const environments = [
     database: testDatabase,
     host,
     dialect,
-    port
+    port,
+    APP_URL_FRONTEND
   },
   {
     name: 'development',
@@ -47,7 +49,8 @@ const environments = [
     database: devDatabase,
     host,
     dialect,
-    port
+    port,
+    APP_URL_FRONTEND
   },
   {
     name: 'production',
@@ -62,7 +65,8 @@ const environments = [
     password,
     host,
     dialect,
-    port
+    port,
+    APP_URL_FRONTEND
   },
   {
     name: 'stagging',
@@ -79,7 +83,8 @@ const environments = [
     database: devDatabase,
     host,
     dialect,
-    port
+    port,
+    APP_URL_FRONTEND
   }
 ];
 

--- a/src/middlewares/shareArticle.js
+++ b/src/middlewares/shareArticle.js
@@ -1,0 +1,41 @@
+
+import open from 'open';
+import dotenv from 'dotenv';
+import env from '../configs/environments';
+import models from '../api/models';
+
+const { Article } = models;
+
+dotenv.config();
+
+const minimumValue = 0;
+const { APP_URL_FRONTEND } = env;
+const facebookShareURL = `https://web.facebook.com/sharer/sharer.php?u=${APP_URL_FRONTEND}/api/articles/`;
+const twitterShareURL = `https://twitter.com/intent/tweet?text=${APP_URL_FRONTEND}/api/articles/`;
+const linkedinShareURL = `https://www.linkedin.com/sharing/share-offsite/?url=${APP_URL_FRONTEND}/api/articles/`;
+
+export default async (req, res, next) => {
+  const { slug } = req.params;
+
+  const { dataValues: { title } } = await Article.findOne({ where: { slug } });
+  req.title = title;
+
+  if (req.url.search(/\/facebook/g) > minimumValue) {
+    req.sharedOn = 'facebook';
+    await open(`${facebookShareURL}${slug}`, { wait: false });
+  } else if (req.url.search(/\/twitter/g) > minimumValue) {
+    req.sharedOn = 'twitter';
+    await open(`${twitterShareURL}${slug}`, { wait: false });
+  } else if (req.url.search(/\/linkedin/g) > minimumValue) {
+    req.sharedOn = 'linkedin';
+    await open(`${linkedinShareURL}${slug}`, { wait: false });
+  } else if (req.url.search(/\/gmail/g) > minimumValue) {
+    req.sharedOn = 'gmail';
+    await open(`mailto:?subject=${title}&body=${APP_URL_FRONTEND}/articles/${slug}`,
+      {
+        wait: false
+      });
+  }
+
+  next();
+};

--- a/tests/socialShare.test.js
+++ b/tests/socialShare.test.js
@@ -1,0 +1,62 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../src/index';
+import status from '../src/helpers/constants/status.codes';
+import signupUser from '../src/helpers/tests/signup';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+const userToken = signupUser();
+const slug = 'What-is-a-Version-1-UUID';
+const title = 'What is a Version 1 UUID';
+
+describe(' testing the social share endpoints', () => {
+  it('should share via facebook', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/share/facebook`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.CREATED);
+        expect(res.body).to.have.property('message').eql(`${title} has been shared successfully on facebook, Thanks`);
+        done();
+      });
+  });
+
+  it('should share via twitter', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/share/twitter`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.CREATED);
+        expect(res.body).to.have.property('message').eql(`${title} has been shared successfully on twitter, Thanks`);
+        done();
+      });
+  });
+
+  it('should share via linkedin', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/share/linkedin`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.CREATED);
+        expect(res.body).to.have.property('message').eql(`${title} has been shared successfully on linkedin, Thanks`);
+        done();
+      });
+  });
+
+  it('should share via gmail', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/share/gmail`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.CREATED);
+        expect(res.body).to.have.property('message').eql(`${title} has been shared successfully on gmail, Thanks`);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### Usecase
[usecase link](https://docs.google.com/document/d/17DU9wCaLMOwjY6ynhosuXFu23xrPr0ZAxVamyBcbGCE/edit)
#### What does this PR do?

this PR opens up a way of sharing the article across Authors-Haven using the following social media platform.
``Facebook`` ``Twitter`` ``Linkedin`` and ``Gmail``

#### Description of Task to be completed?

Have the following endpoint working: 
POST ``/api/articles/: slug/share/where-to-share``: this endpoint will let the user be able to share an article on social media

#### How should this be manually tested?
* Clone the repo and saved it locally on your machine.
* Open the app using any Text Editor
* Run ``npm install``   to install the dependencies.
* Set up the   ``.env`` as instructed by the   ``.env-example``
* Run  ``npm  run dev``.
* Open ``Postman`` or install ``Postman``.
* check the shared article  in the postman using the following endpoint 
 ``POST`` ``/api/articles/:slug/share/where-to-share``.

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#166240839](https://www.pivotaltracker.com/story/show/166240839)