### PR TITLE
#[167284622] Users should be able to report inappropriate comment

### DIFF
--- a/src/api/controllers/reportCommentController.js
+++ b/src/api/controllers/reportCommentController.js
@@ -1,0 +1,53 @@
+import models from '../models';
+import status from '../../helpers/constants/status.codes';
+import errorSender from '../../helpers/error.sender';
+
+const { ReportedComment } = models;
+
+/**
+ * contains a report comment controller
+ * @export
+ * @class CommentReactionController
+ */
+class CommentReactionController {
+  /**
+   * report an inappropriate comment
+   * @static
+   * @param {Object} req the request
+   * @param {Object} res the response to be sent
+   * @memberof CommentReactionController
+   * @returns {Object} res
+   */
+  static async reportComment(req, res) {
+    const commentId = req.params.id;
+    const { commentReason } = req.body;
+    const {
+      user: { id }
+    } = req.user;
+    try {
+      const result = await ReportedComment.findOrCreate({
+        where: {
+          userId: id,
+          reportedCommentId: commentId,
+          reasonId: commentReason
+        }
+      });
+
+      return result[0]._options.isNewRecord === false
+        ? errorSender(status.BAD_REQUEST,
+          res,
+          'Message',
+          'Sorry, You can not report this comment twice with the same comment reason, Thanks ') : res.status(status.CREATED).json({
+          status: status.CREATED,
+          message: 'Reported Successfully'
+        });
+    } catch (SequelizeForeignKeyConstraintError) {
+      errorSender(status.NOT_FOUND,
+        res,
+        'Message',
+        'Sorry, but that reason does not exist, Thanks');
+    }
+  }
+}
+
+export default CommentReactionController;

--- a/src/api/controllers/termsAndConditionsController.js
+++ b/src/api/controllers/termsAndConditionsController.js
@@ -41,7 +41,7 @@ export default class TermsAndConditionController {
       }
     });
     if (!termsDocument) {
-      errorSender(statusCode.NOT_FOUND,
+      return errorSender(statusCode.NOT_FOUND,
         res,
         'terms and conditions',
         'terms and conditions not found');

--- a/src/api/migrations/20200622165311-create-commentReport-table.js
+++ b/src/api/migrations/20200622165311-create-commentReport-table.js
@@ -1,0 +1,46 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('ReportComments', {
+    userId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+      unique: false
+    },
+    reportedCommentId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Comments',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false,
+      unique: false
+    },
+    reasonId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Reasons',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('ReportComments')
+};

--- a/src/api/models/index.js
+++ b/src/api/models/index.js
@@ -24,6 +24,7 @@ const models = {
   Reaction: sequelize.import('./reactions'),
   Rating: sequelize.import('./rating'),
   Read: sequelize.import('./read'),
+  ReportedComment: sequelize.import('./reportComment.js')
 };
 
 Object.keys(models).forEach((key) => {

--- a/src/api/models/reasons.js
+++ b/src/api/models/reasons.js
@@ -13,8 +13,14 @@ export default (sequelize, DataTypes) => {
       }
     },
     {});
-  Reasons.associate = ({ Report }) => {
+  Reasons.associate = ({ Report, ReportedComment }) => {
     Reasons.hasMany(Report, {
+      foreignKey: 'reasonId',
+      sourceKey: 'id',
+      onDelete: 'cascade'
+    });
+
+    Reasons.hasMany(ReportedComment, {
       foreignKey: 'reasonId',
       sourceKey: 'id',
       onDelete: 'cascade'

--- a/src/api/models/reportComment.js
+++ b/src/api/models/reportComment.js
@@ -1,0 +1,41 @@
+export default (sequelize, DataTypes) => {
+  const ReportedComment = sequelize.define('ReportComments', {
+    userId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false
+    },
+    reportedCommentId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Comments',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false
+    },
+    reasonId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Reasons',
+        key: 'id'
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+      allowNull: false
+    }
+  });
+  ReportedComment.removeAttribute('id');
+  ReportedComment.associate = ({ User, Comment, Reason }) => {
+    ReportedComment.belongsTo(User, { foreignKey: 'userId', targetKey: 'id' });
+    ReportedComment.belongsTo(Comment, { foreignKey: 'reportedCommentId', targetKey: 'id' });
+    ReportedComment.belongsTo(Reason, { foreignKey: 'reasonId', targetKey: 'id' });
+  };
+  return ReportedComment;
+};

--- a/src/api/routes/articleRouter.js
+++ b/src/api/routes/articleRouter.js
@@ -21,6 +21,7 @@ import checkIncomingTags from '../../middlewares/check.incoming.tags';
 import createAndGetNewTags from '../../middlewares/get.new.tags';
 import validateTagsTableQueryRoute from '../../middlewares/validations/query.tags.table.route';
 import optionalAuth from '../../middlewares/optionalAuth';
+import reportCommentController from '../controllers/reportCommentController';
 
 const articleRouter = new Router();
 
@@ -157,5 +158,14 @@ articleRouter.delete('/:slug/comments/:id',
 
 articleRouter.patch('/:slug/publish', checkValidToken, checkArticleOwner.checkOwner,
   articleController.publish);
+
+articleRouter.post('/:slug/comments/:id/report',
+  checkValidToken,
+  bodyVerifier,
+  checkArticle.getArticle,
+  getComment,
+  validateInputs('reportComment', ['commentReason']),
+  reportCommentController.reportComment);
+
 
 export default articleRouter;

--- a/src/helpers/constants/error.messages.js
+++ b/src/helpers/constants/error.messages.js
@@ -61,4 +61,6 @@ export default {
   coverImage: 'coverImage is required and must be a string',
   noResult: 'No result found for your request',
   missingProperty: 'Please update this article and put all fields',
+  commentReason: 'commentReason is required and it can not be a string, Please provide a number starting from 1, Thanks'
+
 };

--- a/src/helpers/constants/validation.schemas.js
+++ b/src/helpers/constants/validation.schemas.js
@@ -177,5 +177,11 @@ export default {
       .min(TAGNAME_CONTENT_MIN_LENGTH)
       .max(TAGNAME_CONTENT_MAX_LENGTH)
       .required()
+  }),
+  reportComment: Joi.object().keys({
+    commentReason: number
+      .min(1)
+      .integer()
+      .required()
   })
 };

--- a/src/middlewares/getOneArticle.js
+++ b/src/middlewares/getOneArticle.js
@@ -23,7 +23,6 @@ class getOneArticle {
    */
   static async getArticle(req, res, next) {
     const { slug } = req.params;
-
     const result = await Article.findOne({
       where: {
         slug

--- a/tests/reportComment.test.js
+++ b/tests/reportComment.test.js
@@ -1,0 +1,83 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../src/index';
+import status from '../src/helpers/constants/status.codes';
+import getToken from '../src/helpers/tests/signup';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+const userToken = getToken();
+const slug = 'What-is-a-Version-1-UUID';
+let commentId;
+describe('testing the report comment controller', () => {
+  it('should add a comment on an article', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/comments`)
+      .set('authorization', `${userToken}`)
+      .send({
+        body: "Really interesting article. I've been searching for this"
+      })
+      .end((err, res) => {
+        res.should.have.status(status.CREATED);
+        commentId = res.body.data.id;
+        done();
+      });
+  });
+  it('should be able to report the comment', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/comments/${commentId}/report`)
+      .set('Authorization', userToken)
+      .send({
+        commentReason: 2
+      })
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(status.CREATED);
+        expect(res.body)
+          .to.have.property('message')
+          .eql('Reported Successfully');
+        done();
+      });
+  });
+
+  it('should not be able to report the comment with unexisting reason', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/comments/${commentId}/report`)
+      .set('Authorization', userToken)
+      .send({
+        commentReason: 20
+      })
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(status.NOT_FOUND);
+        expect(res.body.errors)
+          .to.have.property('Message')
+          .eql('Sorry, but that reason does not exist, Thanks');
+        done();
+      });
+  });
+
+  it('should not be able to report the comment twice with same reason', (done) => {
+    chai
+      .request(app)
+      .post(`/api/articles/${slug}/comments/${commentId}/report`)
+      .set('Authorization', userToken)
+      .send({
+        commentReason: 2
+      })
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(status.BAD_REQUEST);
+        expect(res.body.errors)
+          .to.have.property('Message')
+          .eql('Sorry, You can not report this comment twice with the same comment reason, Thanks ');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
[usecase](https://docs.google.com/document/d/1dzILoEQB74O5w6iUCHmdGkqWIOTma-vq9Bb13n8GtzE/edit)
#### What does this PR do?
this PR let the user be able to report a certain comment if it is inappropriate.

#### Description of Task to be completed?
Have the following endpoint working
``POST`` ``api/articles/: slug/commentID/report``

`How does it work?`

Once a user has clicked the report comment button, he then sends data to this endpoint ``POST`` ``api/articles/: slug/:commentID/report`` and then have ``reported successfully`` as a response.
When he tries to hit the endpoint twice, he will still be able to get the same response message, but the data won't be saved twice in the DB.

#### How should this be manually tested?

- Clone the repo to the local machine.
- Run npm install to install the dependencies.
- Set up the .env as instructed by the .env-example
- Run npm setup:dev.
- *Run npm start.
- Send a POST request to /api/articles/:slug/:commentID/report .

#### What are the relevant pivotal tracker stories?
[167284622](https://www.pivotaltracker.com/story/show/167284622)