### PR TITLE
#[16370397] Admin/Moderator should be able to view reported comments and block them.

### DIFF
--- a/src/api/controllers/admin/adminPermissionsController.js
+++ b/src/api/controllers/admin/adminPermissionsController.js
@@ -1,6 +1,6 @@
-import models from '../models';
-import status from '../../helpers/constants/status.codes';
-import paginateUser from '../../helpers/generate.pagination.details';
+import models from '../../models';
+import status from '../../../helpers/constants/status.codes';
+import paginateUser from '../../../helpers/generate.pagination.details';
 
 const generatePagination = paginateUser;
 

--- a/src/api/controllers/admin/commentReportController.js
+++ b/src/api/controllers/admin/commentReportController.js
@@ -1,0 +1,102 @@
+import models from '../../models';
+import status from '../../../helpers/constants/status.codes';
+import paginateUser from '../../../helpers/generate.pagination.details';
+
+const generatePagination = paginateUser;
+
+const {
+  Comment, ReportedComment, User, Reason
+} = models;
+
+/**
+ * contains all method for an admin to read/delete/Block/unblock a comment
+ *
+ * @export
+ * @class AdminReportedCommentController
+ */
+class AdminReportedCommentController {
+  /**
+   * This function gets all the reported comment that are stored in the database
+   *
+   * @author Frank Mutabazi
+   * @static
+   * @param {Object} req the request
+   * @param {Object} res the response to be sent
+   * @memberof AdminReportedCommentController
+   * @returns {Object} res
+   */
+  static async getAllReportedComments(req, res) {
+    const defaultOffset = 0;
+    const defaultLimit = 10;
+    const offset = req.query.offset || defaultOffset;
+    const limit = req.query.limit || defaultLimit;
+    const result = await ReportedComment.findAll({
+      attributes: ['createdAt'],
+      include: [
+        {
+          model: Comment,
+          required: true,
+          attributes: ['id', 'body', 'articleSlug']
+        },
+        {
+          model: User,
+          required: true,
+          attributes: ['username', 'email']
+        },
+        {
+          model: Reason,
+          required: true,
+          attributes: ['description']
+        }
+      ],
+      offset,
+      limit
+    });
+    return res.status(status.OK).send({
+      status: status.OK,
+      paginationDetails: generatePagination(result.length, result, offset, limit),
+      data: result
+    });
+  }
+
+  /**
+   * fetch all reported Comments on a single comment
+   *
+   * @author Frank Mutabazi
+   * @static
+   * @param {object} req - request object
+   * @param {object} res - respond object
+   * @returns {array} response body
+   * @memberof AdminReportedCommentController
+   */
+  static async singleReportedComment(req, res) {
+    const { id } = req.params;
+    const response = await Comment.findOne({
+      where: {
+        id
+      },
+      attributes: ['id', 'body', 'userId', 'articleSlug'],
+      include: [
+        {
+          model: Reason,
+          required: true,
+          attributes: ['id', 'description'],
+          through: {
+            model: ReportedComment,
+            attributes: ['userId']
+          }
+        }
+      ]
+    });
+
+    return response ? res.status(status.OK).send({
+      status: status.OK,
+      data: response
+    }) : res.status(status.OK).send({
+      status: status.OK,
+      message: 'No reports for this comment.'
+    });
+  }
+}
+
+export default AdminReportedCommentController;

--- a/src/api/models/comment.js
+++ b/src/api/models/comment.js
@@ -58,6 +58,11 @@ export default (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       hooks: true
     });
+
+    Comment.belongsToMany(models.Reason, {
+      foreignKey: 'reportedCommentId',
+      through: 'ReportComments'
+    });
   };
   return Comment;
 };

--- a/src/api/models/reasons.js
+++ b/src/api/models/reasons.js
@@ -13,17 +13,16 @@ export default (sequelize, DataTypes) => {
       }
     },
     {});
-  Reasons.associate = ({ Report, ReportedComment }) => {
+  Reasons.associate = ({ Report, Comment }) => {
     Reasons.hasMany(Report, {
       foreignKey: 'reasonId',
       sourceKey: 'id',
       onDelete: 'cascade'
     });
 
-    Reasons.hasMany(ReportedComment, {
+    Reasons.belongsToMany(Comment, {
       foreignKey: 'reasonId',
-      sourceKey: 'id',
-      onDelete: 'cascade'
+      through: 'ReportComments'
     });
   };
   return Reasons;

--- a/src/api/routes/adminRouter.js
+++ b/src/api/routes/adminRouter.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import authController from '../controllers/authController';
-import adminPermissionsController from '../controllers/adminPermissionsController';
+import adminPermissionsController from '../controllers/admin/adminPermissionsController';
 import ValidateUser from '../../middlewares/ValidateUser';
 import validateToken from '../../middlewares/checkValidToken';
 import checkUser from '../../middlewares/checkUser';
@@ -10,6 +10,7 @@ import articleController from '../controllers/articleController';
 import checkIfArticleExist from '../../middlewares/getOneArticle';
 import CheckIfModerator from '../../middlewares/CheckIfModerator';
 import CheckIfBlocked from '../../middlewares/isArticleBlocked';
+import AdminReportedComment from '../controllers/admin/commentReportController';
 
 const adminRouter = new Router();
 
@@ -91,5 +92,15 @@ adminRouter.patch('/article/:slug/unblock',
   checkIfArticleExist.getArticle,
   CheckIfBlocked.checkUnBlocked,
   adminPermissionsController.unBlockArticle);
+
+adminRouter.get('/comments/reported',
+  validateToken,
+  CheckIfModerator.CheckAdmins,
+  AdminReportedComment.getAllReportedComments);
+
+adminRouter.get('/comments/:id/reported',
+  validateToken,
+  CheckIfModerator.CheckAdmins,
+  AdminReportedComment.singleReportedComment);
 
 export default adminRouter;

--- a/src/api/seeders/20190719110459-reportComment.js
+++ b/src/api/seeders/20190719110459-reportComment.js
@@ -1,0 +1,22 @@
+module.exports = {
+  up: queryInterface => queryInterface.bulkInsert('ReportComments',
+    [
+      {
+        userId: 1,
+        reportedCommentId: 6,
+        reasonId: 2,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        userId: 1,
+        reportedCommentId: 6,
+        reasonId: 2,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ],
+    {}),
+
+  down: queryInterface => queryInterface.bulkDelete('ReportComments', null, {})
+};

--- a/src/helpers/tests/adminSignIn.js
+++ b/src/helpers/tests/adminSignIn.js
@@ -1,0 +1,16 @@
+import generateToken from '../tokens/generate.token';
+/**
+ * A function to generate a token for an admin.
+ *
+ * @returns {object} token - The object that contains
+ * the generated token
+ */
+export default () => {
+  const user = {
+    username: 'BurindiAlain12',
+    email: 'alain12@gmail.com',
+    id: 12
+  };
+  const authToken = generateToken(user, process.env.TOKEN_KEY);
+  return authToken;
+};

--- a/tests/admin.reported.comment.test.js
+++ b/tests/admin.reported.comment.test.js
@@ -1,0 +1,69 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../src/index';
+import status from '../src/helpers/constants/status.codes';
+import generateToken from '../src/helpers/tests/adminSignIn';
+
+
+const userToken = generateToken();
+
+const { expect } = chai;
+
+chai.use(chaiHttp);
+
+describe('test the controller for an admin to get reported comment', () => {
+  it('Admin should be able to get all reported comments ', (done) => {
+    chai.request(app)
+      .get('/api/admin/comments/reported')
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.OK);
+        expect(res.body).to.have.property('paginationDetails');
+        expect(res.body.data).to.be.an('array');
+        expect(res.body.data[0]).to.have.property('createdAt').eql(res.body.data[0].createdAt);
+        expect(res.body.data[0]).to.have.property('Comment').to.be.an('object');
+        expect(res.body.data[0].Comment).to.have.property('id').eql(res.body.data[0].Comment.id);
+        expect(res.body.data[0].Comment).to.have.property('body').eql(res.body.data[0].Comment.body);
+        expect(res.body.data[0].Comment).to.have.property('articleSlug').eql(res.body.data[0].Comment.articleSlug);
+        expect(res.body.data[0]).to.have.property('User').to.be.an('object');
+        expect(res.body.data[0].User).to.have.property('username').eql(res.body.data[0].User.username);
+        expect(res.body.data[0].User).to.have.property('email').eql(res.body.data[0].User.email);
+        expect(res.body.data[0]).to.have.property('Reason').to.be.an('object');
+        expect(res.body.data[0].Reason).to.have.property('description').eql(res.body.data[0].Reason.description);
+
+        done();
+      });
+  });
+
+  it('Admin should be able to get all reported comments and respond when there are any reports', (done) => {
+    const id = 4;
+    chai.request(app)
+      .get(`/api/admin/comments/${id}/reported`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.OK);
+        expect(res.body).to.have.property('message').eql('No reports for this comment.');
+        done();
+      });
+  });
+
+  it('Admin should be able to get all reported comments based on a particular commentId', (done) => {
+    const id = 6;
+    chai.request(app)
+      .get(`/api/admin/comments/${id}/reported`)
+      .set('Authorization', userToken)
+      .end((err, res) => {
+        expect(res.body).to.have.property('status').eql(status.OK);
+        expect(res.body.data).to.have.property('id').eql(res.body.data.id);
+        expect(res.body.data).to.have.property('body').eql(res.body.data.body);
+        expect(res.body.data).to.have.property('userId').eql(res.body.data.userId);
+        expect(res.body.data).to.have.property('articleSlug').eql(res.body.data.articleSlug);
+        expect(res.body.data).to.have.property('Reasons').to.be.an('array');
+        expect(res.body.data.Reasons[0]).to.have.property('id').eql(res.body.data.Reasons[0].id);
+        expect(res.body.data.Reasons[0]).to.have.property('description').eql(res.body.data.Reasons[0].description);
+        expect(res.body.data.Reasons[0]).to.have.property('ReportComments').to.be.an('object');
+        expect(res.body.data.Reasons[0].ReportComments).to.have.property('userId').eql(res.body.data.Reasons[0].ReportComments.userId);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
[usecase](https://docs.google.com/document/d/1dzILoEQB74O5w6iUCHmdGkqWIOTma-vq9Bb13n8GtzE/edit)
#### What does this PR do?
this PR let the admin/moderator be able to read all reported comment or a single reported comment.

#### Description of Task to be completed?
Have the following endpoint working
``GET`` ``API/admin/comments/reported``
``GET`` ``API/admin/comments/:slug/reported``

#### How should this be manually tested?

- Clone the repo to the local machine.
- Run npm install to install the dependencies.
- Set up the .env as instructed by the .env-example
- Run npm setup:dev.
- *Run npm start.
- Send a GET request to API/admin/comments/reported  OR API/admin/comments/:slug/reported.

#### What are the relevant pivotal tracker stories?
[16370397](https://www.pivotaltracker.com/story/show/167370397)