### PR TITLE
 ft-#167370397 allow admin and moderator to block or unblock reported comments

### DIFF
--- a/src/api/controllers/admin/commentReportController.js
+++ b/src/api/controllers/admin/commentReportController.js
@@ -89,12 +89,75 @@ class AdminReportedCommentController {
       ]
     });
 
-    return response ? res.status(status.OK).send({
+    return response
+      ? res.status(status.OK).send({
+        status: status.OK,
+        data: response
+      })
+      : res.status(status.OK).send({
+        status: status.OK,
+        message: 'No reports for this comment.'
+      });
+  }
+
+  /**
+   * block Comment
+   *
+   * @static
+   * @param {object} req - request body
+   * @param {object} res - response body
+   * @returns { object } - response
+   * @memberof commentReportController
+   */
+  static async blockComment(req, res) {
+    const { id } = req.params;
+    const { body } = req;
+    const isBlocked = true;
+
+    await Comment.update({
+      isBlocked
+    },
+    {
+      where: {
+        id
+      }
+    });
+    return res.status(status.OK).json({
       status: status.OK,
-      data: response
-    }) : res.status(status.OK).send({
+      message: `${body}:: blocked successfully`,
+      data: {
+        body
+      }
+    });
+  }
+
+  /**
+   * unblock Comment
+   *
+   * @static
+   * @param {object} req - request body
+   * @param {object} res - response body
+   * @returns { object } - response
+   * @memberof commentReportController
+   */
+  static async unBlockComment(req, res) {
+    const { id } = req.params;
+    const isBlocked = false;
+    const { body } = req;
+    await Comment.update({
+      isBlocked
+    },
+    {
+      where: {
+        id
+      }
+    });
+    return res.status(status.OK).json({
       status: status.OK,
-      message: 'No reports for this comment.'
+      message: `${body}:: unblocked successfully`,
+      data: {
+        body
+      }
     });
   }
 }

--- a/src/api/migrations/20190718162333-comment-isBlocked.js
+++ b/src/api/migrations/20190718162333-comment-isBlocked.js
@@ -1,0 +1,8 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn('Comments', 'isBlocked', {
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
+  }),
+
+  down: queryInterface => queryInterface.removeColumn('Comments', 'isBlocked')
+};

--- a/src/api/models/comment.js
+++ b/src/api/models/comment.js
@@ -34,6 +34,10 @@ export default (sequelize, DataTypes) => {
       parentCommentId: {
         type: DataTypes.INTEGER,
         allowNull: true
+      },
+      isBlocked: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
       }
     },
     {

--- a/src/api/routes/adminRouter.js
+++ b/src/api/routes/adminRouter.js
@@ -11,6 +11,8 @@ import checkIfArticleExist from '../../middlewares/getOneArticle';
 import CheckIfModerator from '../../middlewares/CheckIfModerator';
 import CheckIfBlocked from '../../middlewares/isArticleBlocked';
 import AdminReportedComment from '../controllers/admin/commentReportController';
+import CheckIfCommentBlocked from '../../middlewares/isCommentBlocked';
+import checkIfCommentExist from '../../middlewares/checkIfCommentExist';
 
 const adminRouter = new Router();
 
@@ -102,5 +104,18 @@ adminRouter.get('/comments/:id/reported',
   validateToken,
   CheckIfModerator.CheckAdmins,
   AdminReportedComment.singleReportedComment);
+adminRouter.patch('/comments/:id/block',
+  validateToken,
+  CheckIfModerator.CheckAdmins,
+  checkIfCommentExist.checkIfExist,
+  CheckIfCommentBlocked.checkBlockedUnblocked('unblocked'),
+  AdminReportedComment.blockComment);
+
+adminRouter.patch('/comments/:id/unblock',
+  validateToken,
+  CheckIfModerator.CheckAdmins,
+  checkIfCommentExist.checkIfExist,
+  CheckIfCommentBlocked.checkBlockedUnblocked('blocked'),
+  AdminReportedComment.unBlockComment);
 
 export default adminRouter;

--- a/src/api/seeders/20190718163410-reported-comment.js
+++ b/src/api/seeders/20190718163410-reported-comment.js
@@ -1,0 +1,22 @@
+export default {
+  up: queryInterface => queryInterface.bulkInsert('ReportComments',
+    [
+      {
+        userId: 12,
+        reportedCommentId: 5,
+        reasonId: 2,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        userId: 13,
+        reportedCommentId: 6,
+        reasonId: 1,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ],
+    {}),
+
+  down: queryInterface => queryInterface.bulkDelete('ReportComments', null, {})
+};

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -908,6 +908,79 @@
           }
         }
       },
+      "/admin/comment/block/:id": {
+        "patch": {
+          "tags": ["Admin"],
+          "summary": "allow Admin or moderator to block a comment",
+          "description": "",
+          "produces": ["application/json"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "token",
+              "description": "must be admin or moderator",
+              "required": true
+            },
+            {
+              "in": "path",
+              "name": "id",
+              "description": "block comment using commentId",
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "comment blocked successfully"
+            },
+            "401": {
+              "description": "Please you must be the Admin in order to modify the status, Thanks"
+            },
+            "403": {
+              "description": "comment is already a blocked"
+            },
+            "default": {
+              "description": "Something went wrong"
+            }
+          }
+        }
+      },
+
+      "/admin/comment/unblock/:id": {
+        "patch": {
+          "tags": ["Admin"],
+          "summary": "allow Admin and moderator to unblock a comment",
+          "description": "",
+          "produces": ["application/json"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "token",
+              "description": "allow admin or moderator to unblock a comment",
+              "required": true
+            },
+            {
+              "in": "path",
+              "name": "id",
+              "description": "unblock comment using commentId",
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "comment unblocked successfully"
+            },
+            "401": {
+              "description": "Please you must be the Admin in order to modify the status, Thanks"
+            },
+            "403": {
+              "description": "comment is not blocked"
+            },
+            "default": {
+              "description": "Something went wrong"
+            }
+          }
+        }
+      },
 
       "externalDocs": {
         "description": "Find out more about Swagger",

--- a/src/middlewares/checkIfCommentExist.js
+++ b/src/middlewares/checkIfCommentExist.js
@@ -1,0 +1,39 @@
+import models from '../api/models';
+import statusCode from '../helpers/constants/status.codes';
+import sendError from '../helpers/error.sender';
+
+const { Comment } = models;
+/**
+ * check Comment middleware
+ *
+ * @export
+ * @class checkIfCommentExist
+ */
+class checkIfCommentExist {
+  /**
+   * this is a middleware which checks if comment exist.
+   *
+   * @author R
+   * @static
+   * @param {object} req the request
+   * @param {object} res the response to be sent
+   * @param { object } next A callback to allow the node process to continue
+   * @memberof checkIfCommentExist
+   * @returns {Object} res
+   */
+  static async checkIfExist(req, res, next) {
+    const { id } = req.params;
+    const result = await Comment.findOne({
+      where: {
+        id
+      }
+    });
+    if (result) req.article = result.dataValues;
+
+    return result
+      ? next()
+      : sendError(statusCode.NOT_FOUND, res, 'id', `Comment with id ${id} is not found, Thanks`);
+  }
+}
+
+export default checkIfCommentExist;

--- a/src/middlewares/isCommentBlocked.js
+++ b/src/middlewares/isCommentBlocked.js
@@ -1,0 +1,43 @@
+import models from '../api/models';
+import status from '../helpers/constants/status.codes';
+import sendError from '../helpers/error.sender';
+
+const { Comment } = models;
+/**
+ * check if Comment is blocked
+ *
+ * @export
+ * @class checkIfBlocked
+ */
+class checkIfBlocked {
+  /**
+   * this is a middleware which checks if a Comment is blocked.
+   *
+   * @static
+   * @param {String} operation
+   * @memberof checkComment
+   * @returns {Object} res
+   */
+  static checkBlockedUnblocked(operation) {
+    return async (req, res, next) => {
+      const isBlocked = operation === 'blocked';
+      const messageString = isBlocked ? 'unblocked' : 'blocked';
+      const { id } = req.params;
+
+      const result = await Comment.findOne({
+        where: {
+          id,
+          isBlocked
+        }
+      });
+
+      if (result) {
+        req.body = result.dataValues.body;
+        return next();
+      }
+      sendError(status.BAD_REQUEST, res, 'isBlocked', `${id} is already ${messageString}`);
+    };
+  }
+}
+
+export default checkIfBlocked;

--- a/tests/admin.reported.comment.test.js
+++ b/tests/admin.reported.comment.test.js
@@ -4,6 +4,13 @@ import app from '../src/index';
 import status from '../src/helpers/constants/status.codes';
 import generateToken from '../src/helpers/tests/adminSignIn';
 
+chai.use(chaiHttp);
+chai.should();
+
+const adminUrl = '/api/admin/comments';
+const commentId = 5;
+const deleteCommentId = 800;
+const body = 'How to create sequalize seeds::';
 
 const userToken = generateToken();
 
@@ -13,23 +20,46 @@ chai.use(chaiHttp);
 
 describe('test the controller for an admin to get reported comment', () => {
   it('Admin should be able to get all reported comments ', (done) => {
-    chai.request(app)
+    chai
+      .request(app)
       .get('/api/admin/comments/reported')
       .set('Authorization', userToken)
       .end((err, res) => {
-        expect(res.body).to.have.property('status').eql(status.OK);
+        expect(res.body)
+          .to.have.property('status')
+          .eql(status.OK);
         expect(res.body).to.have.property('paginationDetails');
         expect(res.body.data).to.be.an('array');
-        expect(res.body.data[0]).to.have.property('createdAt').eql(res.body.data[0].createdAt);
-        expect(res.body.data[0]).to.have.property('Comment').to.be.an('object');
-        expect(res.body.data[0].Comment).to.have.property('id').eql(res.body.data[0].Comment.id);
-        expect(res.body.data[0].Comment).to.have.property('body').eql(res.body.data[0].Comment.body);
-        expect(res.body.data[0].Comment).to.have.property('articleSlug').eql(res.body.data[0].Comment.articleSlug);
-        expect(res.body.data[0]).to.have.property('User').to.be.an('object');
-        expect(res.body.data[0].User).to.have.property('username').eql(res.body.data[0].User.username);
-        expect(res.body.data[0].User).to.have.property('email').eql(res.body.data[0].User.email);
-        expect(res.body.data[0]).to.have.property('Reason').to.be.an('object');
-        expect(res.body.data[0].Reason).to.have.property('description').eql(res.body.data[0].Reason.description);
+        expect(res.body.data[0])
+          .to.have.property('createdAt')
+          .eql(res.body.data[0].createdAt);
+        expect(res.body.data[0])
+          .to.have.property('Comment')
+          .to.be.an('object');
+        expect(res.body.data[0].Comment)
+          .to.have.property('id')
+          .eql(res.body.data[0].Comment.id);
+        expect(res.body.data[0].Comment)
+          .to.have.property('body')
+          .eql(res.body.data[0].Comment.body);
+        expect(res.body.data[0].Comment)
+          .to.have.property('articleSlug')
+          .eql(res.body.data[0].Comment.articleSlug);
+        expect(res.body.data[0])
+          .to.have.property('User')
+          .to.be.an('object');
+        expect(res.body.data[0].User)
+          .to.have.property('username')
+          .eql(res.body.data[0].User.username);
+        expect(res.body.data[0].User)
+          .to.have.property('email')
+          .eql(res.body.data[0].User.email);
+        expect(res.body.data[0])
+          .to.have.property('Reason')
+          .to.be.an('object');
+        expect(res.body.data[0].Reason)
+          .to.have.property('description')
+          .eql(res.body.data[0].Reason.description);
 
         done();
       });
@@ -37,32 +67,123 @@ describe('test the controller for an admin to get reported comment', () => {
 
   it('Admin should be able to get all reported comments and respond when there are any reports', (done) => {
     const id = 4;
-    chai.request(app)
+    chai
+      .request(app)
       .get(`/api/admin/comments/${id}/reported`)
       .set('Authorization', userToken)
       .end((err, res) => {
-        expect(res.body).to.have.property('status').eql(status.OK);
-        expect(res.body).to.have.property('message').eql('No reports for this comment.');
+        expect(res.body)
+          .to.have.property('status')
+          .eql(status.OK);
+        expect(res.body)
+          .to.have.property('message')
+          .eql('No reports for this comment.');
         done();
       });
   });
 
   it('Admin should be able to get all reported comments based on a particular commentId', (done) => {
     const id = 6;
-    chai.request(app)
+    chai
+      .request(app)
       .get(`/api/admin/comments/${id}/reported`)
       .set('Authorization', userToken)
       .end((err, res) => {
-        expect(res.body).to.have.property('status').eql(status.OK);
-        expect(res.body.data).to.have.property('id').eql(res.body.data.id);
-        expect(res.body.data).to.have.property('body').eql(res.body.data.body);
-        expect(res.body.data).to.have.property('userId').eql(res.body.data.userId);
-        expect(res.body.data).to.have.property('articleSlug').eql(res.body.data.articleSlug);
-        expect(res.body.data).to.have.property('Reasons').to.be.an('array');
-        expect(res.body.data.Reasons[0]).to.have.property('id').eql(res.body.data.Reasons[0].id);
-        expect(res.body.data.Reasons[0]).to.have.property('description').eql(res.body.data.Reasons[0].description);
-        expect(res.body.data.Reasons[0]).to.have.property('ReportComments').to.be.an('object');
-        expect(res.body.data.Reasons[0].ReportComments).to.have.property('userId').eql(res.body.data.Reasons[0].ReportComments.userId);
+        expect(res.body)
+          .to.have.property('status')
+          .eql(status.OK);
+        expect(res.body.data)
+          .to.have.property('id')
+          .eql(res.body.data.id);
+        expect(res.body.data)
+          .to.have.property('body')
+          .eql(res.body.data.body);
+        expect(res.body.data)
+          .to.have.property('userId')
+          .eql(res.body.data.userId);
+        expect(res.body.data)
+          .to.have.property('articleSlug')
+          .eql(res.body.data.articleSlug);
+        expect(res.body.data)
+          .to.have.property('Reasons')
+          .to.be.an('array');
+        expect(res.body.data.Reasons[0])
+          .to.have.property('id')
+          .eql(res.body.data.Reasons[0].id);
+        expect(res.body.data.Reasons[0])
+          .to.have.property('description')
+          .eql(res.body.data.Reasons[0].description);
+        expect(res.body.data.Reasons[0])
+          .to.have.property('ReportComments')
+          .to.be.an('object');
+        expect(res.body.data.Reasons[0].ReportComments)
+          .to.have.property('userId')
+          .eql(res.body.data.Reasons[0].ReportComments.userId);
+        done();
+      });
+  });
+  it('Admin should block reported comment', (done) => {
+    chai
+      .request(app)
+      .patch(`${adminUrl}/${commentId}/block`)
+      .set('Authorization', `${userToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        res.body.should.have.property('message').eql(`${body} blocked successfully`);
+        done();
+      });
+  });
+  it('Admin should not block reported comment which is already blocked', (done) => {
+    chai
+      .request(app)
+      .patch(`${adminUrl}/${commentId}/block`)
+      .set('Authorization', `${userToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.BAD_REQUEST);
+        res.body.should.have
+          .property('errors')
+          .property('isBlocked')
+          .eql(`${commentId} is already blocked`);
+        done();
+      });
+  });
+
+  it('Admin should unblock a blocked comment', (done) => {
+    chai
+      .request(app)
+      .patch(`${adminUrl}/${commentId}/unblock`)
+      .set('Authorization', `${userToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        res.body.should.have.property('message').eql(`${body} unblocked successfully`);
+        done();
+      });
+  });
+  it('Admin should not unblock reported comment which is not blocked', (done) => {
+    chai
+      .request(app)
+      .patch(`${adminUrl}/${commentId}/unblock`)
+      .set('Authorization', `${userToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.BAD_REQUEST);
+        res.body.should.have
+          .property('errors')
+          .property('isBlocked')
+          .eql(`${commentId} is already unblocked`);
+        done();
+      });
+  });
+  it('Admin should not unblock reported comment which is deleted', (done) => {
+    chai
+      .request(app)
+      .patch(`${adminUrl}/${deleteCommentId}/unblock`)
+      .set('Authorization', `${userToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.NOT_FOUND);
+        res.body.should.have
+          .property('errors')
+          .property('id')
+          .eql(`Comment with id ${deleteCommentId} is not found, Thanks`);
         done();
       });
   });


### PR DESCRIPTION
## What does this PR do?
this PR let the admin/moderator be able to block or unblock reported comment
[usecase](https://docs.google.com/document/d/1MWq5TFvgFjr2UzTv-GmYEYp756pvgRkMhchmyo_w3nM/edit?usp=sharing)
#### Description of Task to be completed?
Have the following endpoint working
`PATCH` : `/api/admin/comment/:id/block`
`PATCH` : `/api/admin/comment/:id/unblock`

#### How should this be manually tested?

- Clone the repo to the local machine.
- Run  :
`npm install` 
`npm setup:dev`
`npm start.`

- Send a PATCH request to :
`/api/admin/comment/:id/block`
 `/api/admin/comment/:id/unblock`

#### What are the relevant pivotal tracker stories?
[16370397](https://www.pivotaltracker.com/story/show/167370397)