### PR TITLE
166240833 Users should be able to receive notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "expect.js": "^0.3.1",
     "express": "^4.16.4",
     "express-session": "^1.16.2",
+    "http": "0.0.0",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.11",
@@ -81,6 +82,7 @@
     "sinon": "^7.3.2",
     "sinon-chai": "^3.3.0",
     "slug": "^1.1.0",
+    "socket.io": "^2.2.0",
     "swagger-node-express": "^2.1.3",
     "swagger-ui-express": "^4.0.6",
     "uniqid": "^5.0.3"
@@ -99,6 +101,7 @@
       "src/configs/redisConfigs.js",
       "src/configs/passport.js",
       "src/middlewares/passport.js",
+      "src/middlewares/register.app.js",
       "src/index.js",
       "src/middlewares/errorHandler.js",
       "tests/*",

--- a/src/api/controllers/articleController.js
+++ b/src/api/controllers/articleController.js
@@ -11,7 +11,16 @@ import createTags from '../../helpers/create.article.tags';
 import generateReadtime from '../../helpers/read.time.estimator';
 
 const {
-  Article, Category, User, Report, Share, Highlight, Tag, ArticleTag, Read, Comment
+  Article,
+  Category,
+  User,
+  Report,
+  Share,
+  Highlight,
+  Tag,
+  ArticleTag,
+  Read,
+  Comment
 } = models;
 
 const {
@@ -72,10 +81,9 @@ export default class ArticleController {
       coverImage,
       readTime
     });
-
     if (article) {
       req.article = article.get();
-      if (req.tags) {
+      if (req.body.tags) {
         articleTags = await createTags(req);
       }
       return res.status(CREATED).json({
@@ -87,7 +95,7 @@ export default class ArticleController {
   }
 
   /**
-  * publish a drafted article
+   * publish a drafted article
    * @static
    * @param {Object} req the request
    * @param {Object} res the response to be sent
@@ -103,26 +111,26 @@ export default class ArticleController {
       where: {
         slug,
         title: {
-          [Sequelize.Op.ne]: null,
+          [Sequelize.Op.ne]: null
         },
         body: {
-          [Sequelize.Op.ne]: null,
+          [Sequelize.Op.ne]: null
         },
         description: {
-          [Sequelize.Op.ne]: null,
+          [Sequelize.Op.ne]: null
         },
         category: {
-          [Sequelize.Op.ne]: null,
+          [Sequelize.Op.ne]: null
         },
         coverImage: {
-          [Sequelize.Op.ne]: null,
-        },
+          [Sequelize.Op.ne]: null
+        }
       }
     });
     const published = 1;
     if (article[0] === published) {
       res.status(OK).json({
-        message: 'Your article has been published successfully',
+        message: 'Your article has been published successfully'
       });
     } else {
       errorSender(BAD_REQUEST, res, 'Properties', errorMessage.missingProperty);
@@ -148,7 +156,7 @@ export default class ArticleController {
       include: articleInclude,
       where: {
         status: 'draft',
-        author: id,
+        author: id
       }
     });
 
@@ -201,8 +209,8 @@ export default class ArticleController {
       include: articleInclude,
       where: {
         status: {
-          [Sequelize.Op.ne]: 'draft',
-        },
+          [Sequelize.Op.ne]: 'draft'
+        }
       }
     });
 
@@ -233,8 +241,8 @@ export default class ArticleController {
       where: {
         slug,
         status: {
-          [Sequelize.Op.ne]: 'draft',
-        },
+          [Sequelize.Op.ne]: 'draft'
+        }
       },
       include: articleInclude
     });
@@ -245,7 +253,7 @@ export default class ArticleController {
         await Read.findOrCreate({
           where: {
             userId: req.user.id || req.user.user.id,
-            articleSlug: article.slug,
+            articleSlug: article.slug
           }
         });
       } else {
@@ -254,7 +262,7 @@ export default class ArticleController {
           where: {
             userAgent: req.headers['user-agent'],
             userIp: req.headers['x-forwarded-for'] || req.connection.remoteAddress,
-            articleSlug: article.slug,
+            articleSlug: article.slug
           }
         });
       }
@@ -492,7 +500,7 @@ export default class ArticleController {
   }
 
   /**
-  *
+   *
    * search for artcile according to user's request
    *
    * @static
@@ -534,7 +542,7 @@ export default class ArticleController {
             as: 'Category',
             attributes: ['name']
           }
-        ],
+        ]
       });
       const minArticleLength = 0;
       if (articles.length > minArticleLength) {
@@ -555,15 +563,15 @@ export default class ArticleController {
   }
 
   /**
-  * allow a user to get statistics of an article
-  *
-  * @author Alain Burindi
-  * @static
-  * @param {object} req the request
-  * @param {object} res the response to be sent
-  * @memberof ArticleController
-  * @returns {Object} res
-  */
+   * allow a user to get statistics of an article
+   *
+   * @author Alain Burindi
+   * @static
+   * @param {object} req the request
+   * @param {object} res the response to be sent
+   * @memberof ArticleController
+   * @returns {Object} res
+   */
   static async stats(req, res) {
     const { slug } = req.params;
     const whereClause = {

--- a/src/api/controllers/authController.js
+++ b/src/api/controllers/authController.js
@@ -8,6 +8,7 @@ import env from '../../configs/environments';
 import sendError from '../../helpers/error.sender';
 import errors from '../../helpers/constants/error.messages';
 import mailer from '../../helpers/Mailer/index';
+import setDefaultConfigs from '../../helpers/create.default.notifications.config';
 
 const { User } = models;
 /**
@@ -35,14 +36,22 @@ export default class Auth {
       email,
       password: hashedPassword
     });
-    await mailer('Please verify your email', 'Email verification', email, 'notifications', {
+    await mailer('Please verify your email',
+      'Email verification',
       email,
-      buttonText: 'Verify',
-      userName: username,
-      message:
-        "Please click on the link to verify your email for authors haven.If you didn't request this, simply ignore this e-mail.",
-      link: `${env.baseUrl}/users/verifyEmail`
-    });
+      'passwordResetEmailConfig',
+      {
+        email,
+        buttonText: 'Verify',
+        userName: username,
+        message:
+          "Please click on the link to verify your email for authors haven.If you didn't request this, simply ignore this e-mail.",
+        link: `${env.baseUrl}/users/verifyEmail`
+      });
+
+    // setting default notifications configurations
+    await setDefaultConfigs(user.dataValues.id);
+
     const tokenData = { id: user.dataValues.id, username, email };
     const token = generateToken(tokenData, env.secret);
     return sendResult(res, status.CREATED, 'user created successfully', user, token);

--- a/src/api/controllers/commentController.js
+++ b/src/api/controllers/commentController.js
@@ -22,7 +22,7 @@ class CommentController {
    * @param {object} req - this is the request object
    * @param {object} res - this is the response object
    * @returns {object} - this function returns an object
-   * @memberof RatingsController
+   * @memberof commentController
    */
   static async create(req, res) {
     // Initializing variables
@@ -86,7 +86,7 @@ class CommentController {
    * @param {object} req - this is the request object
    * @param {object} res - this is the response object
    * @returns {object} - this function returns an object
-   * @memberof RatingsController
+   * @memberof commentController
    */
   static async getComments(req, res) {
     // Initializing variables
@@ -133,7 +133,7 @@ class CommentController {
    * @param {object} req - this is the request object
    * @param {object} res - this is the response object
    * @returns {object} - this function returns an object
-   * @memberof RatingsController
+   * @memberof commentController
    */
   static async updateComment(req, res) {
     // Initializing variables
@@ -163,7 +163,7 @@ class CommentController {
    * @param {object} req - this is the request object
    * @param {object} res - this is the response object
    * @returns {object} - this function returns an object
-   * @memberof RatingsController
+   * @memberof commentController
    */
   static async deleteComment(req, res) {
     // Initializing variables
@@ -180,6 +180,37 @@ class CommentController {
       status: status.OK,
       message: 'Comment deleted successfully'
     });
+  }
+
+  /**
+   * A method to get a single comment
+   *
+   * @author Prémices
+   * @static
+   * @param {object} req - this is the request object
+   * @param {object} res - this is the response object
+   * @returns {object} - this function returns an object
+   * @memberof commentController
+   */
+  static async getSingleComment(req, res) {
+    // Initializing variables
+    const { slug, id } = req.params;
+
+    try {
+      const comment = await Comment.findOne({
+        where: {
+          id,
+          articleSlug: slug
+        }
+      });
+
+      res.status(status.OK).json({
+        status: status.OK,
+        data: comment
+      });
+    } catch (error) {
+      sendError(status.NOT_FOUND, res, 'comment', errorMessages.noComment);
+    }
   }
 }
 export default CommentController;

--- a/src/api/controllers/notificationController.js
+++ b/src/api/controllers/notificationController.js
@@ -1,0 +1,166 @@
+import _ from 'lodash';
+import models from '../models';
+import status from '../../helpers/constants/status.codes';
+import sendError from '../../helpers/error.sender';
+import errorMessages from '../../helpers/constants/error.messages';
+import emailUnsubscriptionConfig from '../../helpers/constants/email.unsubscription.config.json';
+
+const { NotificationConfig, Notification } = models;
+
+/**
+ * A function to send the result back for notifications GET requests
+ *
+ * @param {Object} Notifications - The sequelize return value
+ * @param {Object} ResultObject - The result object
+ * @param {Object} Res -  The express result object
+ * @returns {Object} result - The result object
+ */
+const sendNotificationResult = (Notifications, ResultObject, Res) => {
+  if (!_.isEmpty(Notifications)) {
+    // Sending the result
+    ResultObject.status = status.OK;
+    ResultObject.data = Notifications;
+    return Res.status(status.OK).json(ResultObject);
+  }
+  return sendError(status.NOT_FOUND, Res, 'notifications', errorMessages.notificationNotFound);
+};
+
+/**
+ * A class to handle all notifications
+ */
+export default class NotificationController {
+  /**
+   * A method to get user configs
+   * @param  {object} req
+   * @param  {object} res
+   * @return {object} return an object containing set configuration
+   */
+  static async getConfig(req, res) {
+    // Initializing variables
+    const result = {};
+    const {
+      user: { id }
+    } = req.user;
+
+    const userConfig = await NotificationConfig.findOne({
+      userId: id
+    });
+
+    userConfig.config = JSON.parse(userConfig.config);
+
+    // Sending the result
+    result.status = status.OK;
+    result.config = userConfig;
+    return res.status(status.OK).json(result);
+  }
+
+  /**
+   * A method to update user configs
+   * @param  {object} req
+   * @param  {object} res
+   * @return {object} return an object containing set configuration
+   */
+  static async updateConfig(req, res) {
+    // Initializing variables
+    const result = {};
+    const { user: { id } } = req.user;
+    const isUnsubscribeRequest = req.url.includes('email');
+    // Updating the configuration
+    if (isUnsubscribeRequest) {
+      await NotificationConfig.update({
+        config: JSON.stringify(emailUnsubscriptionConfig)
+      },
+      { where: { userId: id } });
+    } else {
+      await NotificationConfig.update({
+        config: JSON.stringify(req.body)
+      },
+      { where: { userId: id } });
+    }
+    // sending the result back
+    result.status = status.OK;
+    result.message = 'Configurations updated successfully';
+    return res.status(status.OK).json({ result });
+  }
+
+  /**
+   * A method to get all seen/unseen notifications of a user
+   * @param  {object} req
+   * @param  {object} res
+   * @return {object} return an object containing all notifications
+   */
+  static async getSeenUnseen(req, res) {
+    // Initializing variables
+    const result = {};
+    const {
+      user: { id }
+    } = req.user;
+    const isUnseenRequest = req.url.includes('unseen');
+    let notifications;
+
+    if (isUnseenRequest) {
+      notifications = await Notification.findAll({
+        where: {
+          userId: id,
+          status: 'unseen'
+        }
+      });
+    } else {
+      notifications = await Notification.findAll({
+        where: {
+          userId: id,
+          status: 'seen'
+        }
+      });
+    }
+    sendNotificationResult(notifications, result, res);
+  }
+
+  /**
+   * A method to get all notifications of a user
+   * @param  {object} req
+   * @param  {object} res
+   * @return {object} return an object containing all notifications
+   */
+  static async getAll(req, res) {
+    // Initializing variables
+    const result = {};
+    const {
+      user: { id }
+    } = req.user;
+
+    const notifications = await Notification.findAll({
+      where: {
+        userId: id
+      }
+    });
+    sendNotificationResult(notifications, result, res);
+  }
+
+  /**
+   * A method to update a single notification
+   * @param  {object} req
+   * @param  {object} res
+   * @return {object} return an object
+   */
+  static async updateNotification(req, res) {
+    const result = {};
+    const { user: { id: userId } } = req.user;
+    const { id } = req.params;
+    const isUnseenRequest = req.url.includes('unseen');
+    if (isUnseenRequest) {
+      await Notification.update({
+        status: 'unseen'
+      },
+      { where: { id, userId } });
+    } else {
+      await Notification.update({
+        status: 'seen'
+      },
+      { where: { id, userId } });
+    }
+    result.status = status.OK;
+    result.message = 'Notification updated successfully';
+    return res.status(status.OK).json(result);
+  }
+}

--- a/src/api/controllers/password.reset.js
+++ b/src/api/controllers/password.reset.js
@@ -26,15 +26,19 @@ export default class PasswordReset {
     const result = {};
     const { username, email } = req.user;
 
-    await mailer(`Password recovery for ${email}`, 'Password recovery', email, 'notifications', {
+    await mailer(`Password recovery for ${email}`,
+      'Password recovery',
       email,
-      link: `${env.baseUrl}/api/password-reset`,
-      userName: username,
-      buttonText: 'RESET',
-      message:
-        "You are receiving this email because you've requested the recovery "
-        + 'of your Authors Heaven password. Kindly click the button below.'
-    });
+      'passwordResetEmailConfig',
+      {
+        email,
+        link: `${env.baseUrl}/api/password-reset`,
+        userName: username,
+        buttonText: 'RESET',
+        message:
+          "You are receiving this email because you've requested the recovery "
+          + 'of your Authors Heaven password. Kindly click the button below.'
+      });
 
     // Sending the result
     result.status = status.OK;

--- a/src/api/controllers/reportCommentController.js
+++ b/src/api/controllers/reportCommentController.js
@@ -37,7 +37,8 @@ class CommentReactionController {
         ? errorSender(status.BAD_REQUEST,
           res,
           'Message',
-          'Sorry, You can not report this comment twice with the same comment reason, Thanks ') : res.status(status.CREATED).json({
+          'Sorry, You can not report this comment twice with the same comment reason, Thanks ')
+        : res.status(status.CREATED).json({
           status: status.CREATED,
           message: 'Reported Successfully'
         });

--- a/src/api/migrations/20190708141337-create-stat.js
+++ b/src/api/migrations/20190708141337-create-stat.js
@@ -1,33 +1,30 @@
 export default {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('Reads', {
-      id: {
-        allowNull: false,
-        autoIncrement: true,
-        primaryKey: true,
-        type: Sequelize.INTEGER
-      },
-      articleSlug: {
-        type: Sequelize.STRING,
-        references: { model: 'Articles', key: 'slug' }
-      },
-      userIp: {type: Sequelize.STRING},
-      userAgent: {type: Sequelize.STRING},
-      userId: {
-        type: Sequelize.INTEGER,
-        references: { model: 'Users', key: 'id' }
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      }
-    });
-  },
-  down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('Reads');
-  }
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Reads', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    articleSlug: {
+      type: Sequelize.STRING,
+      references: { model: 'Articles', key: 'slug' },
+      onDelete: 'CASCADE'
+    },
+    userIp: { type: Sequelize.STRING },
+    userAgent: { type: Sequelize.STRING },
+    userId: {
+      type: Sequelize.INTEGER,
+      references: { model: 'Users', key: 'id' }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: (queryInterface, Sequelize) => queryInterface.dropTable('Reads')
 };

--- a/src/api/migrations/20190717152603-create-notifications-table.js
+++ b/src/api/migrations/20190717152603-create-notifications-table.js
@@ -1,0 +1,47 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Notifications', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    message: {
+      type: Sequelize.TEXT,
+      allowNull: false
+    },
+    url: {
+      type: Sequelize.STRING,
+      allowNull: true
+    },
+    status: {
+      type: Sequelize.ENUM('seen', 'unseen'),
+      allowNull: false,
+      defaultValue: 'unseen'
+    },
+    type: {
+      type: Sequelize.STRING,
+      allowNull: false,
+      default: 'inApp'
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Notifications')
+};

--- a/src/api/migrations/20190717153700-create-notifications-config-table.js
+++ b/src/api/migrations/20190717153700-create-notifications-config-table.js
@@ -1,0 +1,34 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('NotificationConfigs', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    config: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('NotificationConfigs')
+};

--- a/src/api/models/comment.js
+++ b/src/api/models/comment.js
@@ -1,3 +1,5 @@
+import eventEmitter from '../../helpers/event.emitter';
+
 export default (sequelize, DataTypes) => {
   const Comment = sequelize.define('Comments',
     {
@@ -41,7 +43,14 @@ export default (sequelize, DataTypes) => {
       }
     },
     {
-      freezeTableName: true
+      freezeTableName: true,
+      hooks: {
+        afterBulkUpdate: (data) => {
+          if (data.attributes.isBlocked) {
+            eventEmitter.emit('blockComment', 'block', data.where.id);
+          } else eventEmitter.emit('unblockComment', 'unblock', data.where.id);
+        }
+      }
     });
 
   Comment.associate = (models) => {

--- a/src/api/models/index.js
+++ b/src/api/models/index.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill';
 import Sequelize from 'sequelize';
 import env from '../../configs/environments';
 
@@ -24,7 +25,9 @@ const models = {
   Reaction: sequelize.import('./reactions'),
   Rating: sequelize.import('./rating'),
   Read: sequelize.import('./read'),
-  ReportedComment: sequelize.import('./reportComment.js')
+  ReportedComment: sequelize.import('./reportComment.js'),
+  Notification: sequelize.import('./notification'),
+  NotificationConfig: sequelize.import('./notificationConfig')
 };
 
 Object.keys(models).forEach((key) => {

--- a/src/api/models/notification.js
+++ b/src/api/models/notification.js
@@ -1,0 +1,52 @@
+export default (sequelize, DataTypes) => {
+  const Notification = sequelize.define('Notifications',
+    {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: DataTypes.INTEGER
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      message: {
+        type: DataTypes.TEXT,
+        allowNull: false
+      },
+      url: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      status: {
+        type: DataTypes.ENUM('seen', 'unseen'),
+        allowNull: false,
+        defaultValue: 'unseen'
+      },
+      type: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        default: 'inApp'
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    },
+    {});
+  Notification.associate = (models) => {
+    Notification.belongsTo(models.User, { foreignKey: 'userId' });
+  };
+  return Notification;
+};

--- a/src/api/models/notificationConfig.js
+++ b/src/api/models/notificationConfig.js
@@ -1,0 +1,39 @@
+export default (sequelize, DataTypes) => {
+  const NotificationConfig = sequelize.define('NotificationConfig',
+    {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: DataTypes.INTEGER
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      config: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      }
+    },
+    {});
+  NotificationConfig.associate = (models) => {
+    NotificationConfig.belongsTo(models.User, { foreignKey: 'userId' });
+  };
+  return NotificationConfig;
+};

--- a/src/api/models/report.js
+++ b/src/api/models/report.js
@@ -1,38 +1,50 @@
 import user from './user';
+import eventEmitter from '../../helpers/event.emitter';
 
 export default (sequelize, DataTypes) => {
-  const Report = sequelize.define('Reports', {
-    userId: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: 'Users',
-        key: 'id'
+  const Report = sequelize.define('Reports',
+    {
+      userId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false
       },
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-      allowNull: false
+      reportedArticleSlug: {
+        type: DataTypes.STRING,
+        references: {
+          model: 'Articles',
+          key: 'slug'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false
+      },
+      reasonId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Reasons',
+          key: 'id'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false
+      }
     },
-    reportedArticleSlug: {
-      type: DataTypes.STRING,
-      references: {
-        model: 'Articles',
-        key: 'slug'
-      },
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-      allowNull: false
-    },
-    reasonId: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: 'Reasons',
-        key: 'id'
-      },
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-      allowNull: false
-    }
-  });
+    {
+      hooks: {
+        afterCreate: async (report) => {
+          const currentData = report.get();
+          if (currentData) {
+            eventEmitter.emit('reportArticle', currentData.reportedArticleSlug);
+          }
+        }
+      }
+    });
   Report.removeAttribute('id');
   Report.associate = ({ User, Article, Reason }) => {
     Report.belongsTo(User, { foreignKey: 'userId', targetKey: 'id' });

--- a/src/api/models/reportComment.js
+++ b/src/api/models/reportComment.js
@@ -1,36 +1,49 @@
+import eventEmitter from '../../helpers/event.emitter';
+
 export default (sequelize, DataTypes) => {
-  const ReportedComment = sequelize.define('ReportComments', {
-    userId: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: 'Users',
-        key: 'id'
+  const ReportedComment = sequelize.define('ReportComments',
+    {
+      userId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false
       },
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-      allowNull: false
+      reportedCommentId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Comments',
+          key: 'id'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false
+      },
+      reasonId: {
+        type: DataTypes.INTEGER,
+        references: {
+          model: 'Reasons',
+          key: 'id'
+        },
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        allowNull: false
+      }
     },
-    reportedCommentId: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: 'Comments',
-        key: 'id'
-      },
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-      allowNull: false
-    },
-    reasonId: {
-      type: DataTypes.INTEGER,
-      references: {
-        model: 'Reasons',
-        key: 'id'
-      },
-      onDelete: 'CASCADE',
-      onUpdate: 'CASCADE',
-      allowNull: false
-    }
-  });
+    {
+      hooks: {
+        afterCreate: async (report) => {
+          const currentData = report.get();
+          if (currentData) {
+            eventEmitter.emit('reportComment', currentData.reportedCommentId);
+          }
+        }
+      }
+    });
   ReportedComment.removeAttribute('id');
   ReportedComment.associate = ({ User, Comment, Reason }) => {
     ReportedComment.belongsTo(User, { foreignKey: 'userId', targetKey: 'id' });

--- a/src/api/models/user.js
+++ b/src/api/models/user.js
@@ -106,6 +106,12 @@ export default (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
       hooks: true
     });
+    User.hasMany(models.Notification, {
+      foreignKey: 'userId'
+    });
+    User.hasMany(models.NotificationConfig, {
+      foreignKey: 'userId'
+    });
   };
 
   User.findByEmail = (email) => {

--- a/src/api/routes/articleRouter.js
+++ b/src/api/routes/articleRouter.js
@@ -83,7 +83,6 @@ articleRouter.post('/:slug/highlight',
 
 articleRouter.get('/:slug/highlight', checkArticle.getArticle, articleController.getHighlight);
 
-
 articleRouter.post('/:slug/report',
   checkValidToken,
   bodyVerifier,
@@ -156,7 +155,14 @@ articleRouter.delete('/:slug/comments/:id',
   checkCommentOwner,
   commentController.deleteComment);
 
-articleRouter.patch('/:slug/publish', checkValidToken, checkArticleOwner.checkOwner,
+articleRouter.get('/:slug/comments/:id',
+  checkValidToken,
+  validateCommentUpdateDelete,
+  commentController.getSingleComment);
+
+articleRouter.patch('/:slug/publish',
+  checkValidToken,
+  checkArticleOwner.checkOwner,
   articleController.publish);
 
 articleRouter.post('/:slug/comments/:id/report',
@@ -166,6 +172,5 @@ articleRouter.post('/:slug/comments/:id/report',
   getComment,
   validateInputs('reportComment', ['commentReason']),
   reportCommentController.reportComment);
-
 
 export default articleRouter;

--- a/src/api/routes/index.js
+++ b/src/api/routes/index.js
@@ -6,6 +6,7 @@ import profileRouter from './profileRouter';
 import authorsRouter from './authorsRoutes';
 import adminRouter from './adminRouter';
 import bookmarkRouter from './bookmarkRouter';
+import notificationRouter from './notificationRouter';
 
 import authenticate from '../../middlewares/authenticate';
 import termsAndConditionsRouter from './termsAndConditions';
@@ -19,6 +20,7 @@ router.use('/authors', authorsRouter);
 router.use('/profiles', profileRouter);
 router.use('/admin', adminRouter);
 router.use('/bookmarks', bookmarkRouter);
+router.use('/notifications', notificationRouter);
 
 router.use('/profiles', authenticate, profileRouter);
 router.use('/termsAndConditions', termsAndConditionsRouter);

--- a/src/api/routes/notificationRouter.js
+++ b/src/api/routes/notificationRouter.js
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import notificationController from '../controllers/notificationController';
+import checkValidToken from '../../middlewares/checkValidToken';
+import validateInputs from '../../middlewares/validations/body.inputs';
+import bodyVerifier from '../../middlewares/validations/body.verifier';
+import checkUpdateNotification from '../../middlewares/check.update.notification';
+
+const router = new Router();
+
+router.patch('/configuration',
+  checkValidToken,
+  bodyVerifier,
+  validateInputs('notificationConfig', ['inApp']),
+  notificationController.updateConfig);
+
+router.get('/configuration', checkValidToken, notificationController.getConfig);
+
+router.get('/', checkValidToken, notificationController.getAll);
+router.get('/seen', checkValidToken, notificationController.getSeenUnseen);
+router.get('/unseen', checkValidToken, notificationController.getSeenUnseen);
+
+router.patch('/:id/seen',
+  checkValidToken,
+  checkUpdateNotification,
+  notificationController.updateNotification);
+
+router.patch('/:id/unseen',
+  checkValidToken,
+  checkUpdateNotification,
+  notificationController.updateNotification);
+
+router.get('/configuration/unsubscribe/email',
+  checkValidToken,
+  notificationController.updateConfig);
+
+export default router;

--- a/src/api/seeders/20190621184055-user.js
+++ b/src/api/seeders/20190621184055-user.js
@@ -109,6 +109,7 @@ module.exports = {
         username: 'BurindiAlain14',
         email: 'alain14@gmail.com',
         password: hashedPassword,
+        role: 'moderator',
         createdAt: new Date(),
         updatedAt: new Date()
       },
@@ -293,7 +294,7 @@ module.exports = {
         password: hashedPassword,
         createdAt: new Date(),
         updatedAt: new Date()
-      },
+      }
     ],
     {}),
 

--- a/src/api/seeders/20190718104706-test-notification-configs.js
+++ b/src/api/seeders/20190718104706-test-notification-configs.js
@@ -1,0 +1,28 @@
+import notificationsDefaultConfigs from '../../helpers/constants/default.notification.configs.json';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.bulkInsert('NotificationConfigs',
+    [
+      {
+        userId: 1,
+        config: JSON.stringify(notificationsDefaultConfigs),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        userId: 13,
+        config: JSON.stringify(notificationsDefaultConfigs),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        userId: 14,
+        config: JSON.stringify(notificationsDefaultConfigs),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ],
+    {}),
+
+  down: (queryInterface, Sequelize) => queryInterface.bulkDelete('NotificationConfigs', null, {})
+};

--- a/src/helpers/Mailer/index.js
+++ b/src/helpers/Mailer/index.js
@@ -27,6 +27,9 @@ export default (messageTitle, emailSubject, reciever, operation, userData) => {
              <div style="padding:35px 10px;text-align:center; font-size: 95%;">
              Copyright, 2019<br>
              Andela, Savage Rangers
+             <a target="_blank" onMouseOver="this.style.color='red'" onMouseOut="this.style.color='blue'" href="${
+  env.baseUrl
+}/api/notifications/configuration/unsubscribe/email">Unsubscribe</a>
              </div>
              </div>`
     };

--- a/src/helpers/Mailer/templates/index.js
+++ b/src/helpers/Mailer/templates/index.js
@@ -1,5 +1,7 @@
+import passwordResetEmailConfig from './passwordResetEmailConfig';
 import notifications from './notifications';
 
 export default {
-  notifications,
+  passwordResetEmailConfig,
+  notifications
 };

--- a/src/helpers/Mailer/templates/notifications.js
+++ b/src/helpers/Mailer/templates/notifications.js
@@ -1,18 +1,19 @@
-import generateLink from '../../tokens/generate.link';
-
 export default (userData) => {
-  const link = generateLink(userData.link, {
-    email: userData.email,
-  });
   const html = `<div style="background: #F5F4F4; padding: 3%; ">
                 Hello ${userData.userName}!!<br><br>
                 
                 ${userData.message}<br><br>
                 <div style="text-align: center; padding: 2%;"><a target="_blank" style="background: #2F3640; color: white; text-decoration: none;
-                padding: 2% 10% 2% 10%; margin-top: 1%; " href="${link}" onMouseOver="this.style.background='#586170'; this.style.color='white'"
-                onMouseOut="this.style.color='white'; this.style.background='#2F3640';">${userData.buttonText}</a><br><br></div>
+                padding: 2% 10% 2% 10%; margin-top: 1%; " href="${
+  userData.url
+}" onMouseOver="this.style.background='#586170'; this.style.color='white'"
+                onMouseOut="this.style.color='white'; this.style.background='#2F3640';">${
+  userData.buttonText
+}</a><br><br></div>
                 If it doesn't 
-                work, click this link <a target="_blank" onMouseOver="this.style.color='red'" onMouseOut="this.style.color='blue'" href="${link}">${link}</a>
+                work, click this link <a target="_blank" onMouseOver="this.style.color='red'" onMouseOut="this.style.color='blue'" href="${
+  userData.url
+}">${userData.url}</a>
                 </div>`;
   return html;
 };

--- a/src/helpers/Mailer/templates/passwordResetEmailConfig.js
+++ b/src/helpers/Mailer/templates/passwordResetEmailConfig.js
@@ -1,0 +1,18 @@
+import generateLink from '../../tokens/generate.link';
+
+export default (userData) => {
+  const link = generateLink(userData.link, {
+    email: userData.email,
+  });
+  const html = `<div style="background: #F5F4F4; padding: 3%; ">
+                Hello ${userData.userName}!!<br><br>
+                
+                ${userData.message}<br><br>
+                <div style="text-align: center; padding: 2%;"><a target="_blank" style="background: #2F3640; color: white; text-decoration: none;
+                padding: 2% 10% 2% 10%; margin-top: 1%; " href="${link}" onMouseOver="this.style.background='#586170'; this.style.color='white'"
+                onMouseOut="this.style.color='white'; this.style.background='#2F3640';">${userData.buttonText}</a><br><br></div>
+                If it doesn't 
+                work, click this link <a target="_blank" onMouseOver="this.style.color='red'" onMouseOut="this.style.color='blue'" href="${link}">${link}</a>
+                </div>`;
+  return html;
+};

--- a/src/helpers/constants/default.notification.configs.json
+++ b/src/helpers/constants/default.notification.configs.json
@@ -1,0 +1,22 @@
+{
+  "inApp": {
+    "articles": {
+      "show": true,
+      "on": ["report", "block"]
+    },
+    "comments": {
+      "show": true,
+      "on": ["report", "block"]
+    }
+  },
+  "email": {
+    "articles": {
+      "show": true,
+      "on": ["report", "block"]
+    },
+    "comments": {
+      "show": true,
+      "on": ["report", "block"]
+    }
+  }
+}

--- a/src/helpers/constants/email.unsubscription.config.json
+++ b/src/helpers/constants/email.unsubscription.config.json
@@ -1,0 +1,22 @@
+{
+  "inApp": {
+    "articles": {
+      "show": true,
+      "on": ["report", "block"]
+    },
+    "comments": {
+      "show": true,
+      "on": ["report", "block"]
+    }
+  },
+  "email": {
+    "articles": {
+      "show": false,
+      "on": ["report", "block"]
+    },
+    "comments": {
+      "show": false,
+      "on": ["report", "block"]
+    }
+  }
+}

--- a/src/helpers/constants/error.messages.js
+++ b/src/helpers/constants/error.messages.js
@@ -61,6 +61,11 @@ export default {
   coverImage: 'coverImage is required and must be a string',
   noResult: 'No result found for your request',
   missingProperty: 'Please update this article and put all fields',
-  commentReason: 'commentReason is required and it can not be a string, Please provide a number starting from 1, Thanks'
+  commentReason:
+    'commentReason is required and it can not be a string, Please provide a number starting from 1, Thanks',
 
+  inApp: 'inApp is required and must be an object',
+  configNotModified: 'you already have set configurations',
+  configNotFound: 'you have to set configurations first',
+  notificationNotFound: 'No notifications found for now, Thanks'
 };

--- a/src/helpers/constants/validation.schemas.js
+++ b/src/helpers/constants/validation.schemas.js
@@ -1,6 +1,6 @@
 /**
  * reset password Validation Schema description file
- * @name reset.password
+ * @name validationSchemas
  */
 
 import Joi from '@hapi/joi';
@@ -31,6 +31,27 @@ const TAGNAME_CONTENT_MAX_LENGTH = 30;
 
 const DEFAULT_OFFSET = 0;
 const DEFAULT_LIMIT = 10;
+
+const configureNotification = Joi.object()
+  .keys({
+    articles: Joi.object()
+      .keys({
+        show: Joi.boolean().required(),
+        on: Joi.array()
+          .items(Joi.string().valid(['report', 'block']))
+          .required()
+      })
+      .required(),
+    comments: Joi.object()
+      .keys({
+        show: Joi.boolean().required(),
+        on: Joi.array()
+          .items(Joi.string().valid(['report', 'block']))
+          .required()
+      })
+      .required()
+  })
+  .required();
 
 export default {
   resetPassword: Joi.object().keys({
@@ -183,5 +204,12 @@ export default {
       .min(1)
       .integer()
       .required()
-  })
+  }),
+
+  notificationConfig: Joi.object()
+    .keys({
+      inApp: configureNotification,
+      email: configureNotification
+    })
+    .required()
 };

--- a/src/helpers/create.default.notifications.config.js
+++ b/src/helpers/create.default.notifications.config.js
@@ -1,0 +1,21 @@
+/**
+ * A helper to create default notification configurations when a user
+ * is signed up
+ * @name defaultNotificationConfigs
+ * @author Prémices
+ */
+
+import models from '../api/models';
+import defaultNotificationConfigs from './constants/default.notification.configs.json';
+
+const { NotificationConfig } = models;
+
+export default (id) => {
+  // Inserting the default configurations into the database
+  const config = NotificationConfig.create({
+    userId: id,
+    config: JSON.stringify(defaultNotificationConfigs)
+  });
+
+  return config.get();
+};

--- a/src/helpers/event.emitter.js
+++ b/src/helpers/event.emitter.js
@@ -1,0 +1,12 @@
+/**
+ * The reason why his file contains only one instance of 'events'
+ * is to synchronize all the events that will be emitted in the whole
+ * server
+ *
+ * @name eventEmitter
+ * @author Prémices
+ */
+
+import EventEmitter from 'events';
+
+export default new EventEmitter();

--- a/src/helpers/event.listeners.js
+++ b/src/helpers/event.listeners.js
@@ -1,0 +1,22 @@
+/* eslint-disable import/no-cycle */
+/**
+ * This file contains all event listeners of the server
+ */
+
+import eventEmitter from './event.emitter';
+import reportArticle from './notifications/report.article';
+import blockArticle from './notifications/block.article';
+import reportComment from './notifications/report.comment';
+import blockComment from './notifications/block.comment';
+
+export default () => {
+  // Article events
+  eventEmitter.on('reportArticle', reportArticle);
+  eventEmitter.on('blockArticle', blockArticle);
+  eventEmitter.on('unblockArticle', blockArticle);
+
+  // Comment events
+  eventEmitter.on('reportComment', reportComment);
+  eventEmitter.on('blockComment', blockComment);
+  eventEmitter.on('unblockComment', blockComment);
+};

--- a/src/helpers/notifications/block.article.js
+++ b/src/helpers/notifications/block.article.js
@@ -1,0 +1,44 @@
+// eslint-disable-next-line import/no-cycle
+import { io } from '../../index';
+import env from '../../configs/environments';
+import models from '../../api/models';
+import sendNotification from './sender';
+
+const { Article, User } = models;
+
+export default async (operation, articleSlug) => {
+  try {
+    const url = `${env.baseUrl}/api/articles`;
+
+    const message = {
+      inAppMessage: '',
+      emailMessage: '',
+      emailButtonText: ''
+    };
+
+    const article = await Article.findOne({
+      attributes: ['title'],
+      include: {
+        model: User,
+        required: true,
+        attributes: ['id', 'email', 'username']
+      },
+      where: {
+        slug: articleSlug
+      }
+    });
+
+    message.inAppMessage = `The article ${article.title} has been ${operation}ed`;
+    message.emailMessage = `The article ${
+      article.title
+    } has been ${operation}ed. Click the button bellow to follow up`;
+    message.emailButtonText = 'Follow';
+
+    const notification = await sendNotification('articles', 'report', article.User, message, url);
+    io.emit(`${operation}Article`, notification);
+
+    return notification;
+  } catch (error) {
+    return { errors: error };
+  }
+};

--- a/src/helpers/notifications/block.comment.js
+++ b/src/helpers/notifications/block.comment.js
@@ -1,0 +1,56 @@
+// eslint-disable-next-line import/no-cycle
+import { io } from '../../index';
+import env from '../../configs/environments';
+import models from '../../api/models';
+import sendNotification from './sender';
+
+const { Article, User, Comment } = models;
+
+export default async (operation, commentId) => {
+  try {
+    const substringInitialIndex = 0;
+    const substringFinalIndex = 20;
+    const comment = await Comment.findOne({
+      attributes: ['body'],
+      include: [
+        {
+          model: Article,
+          attributes: ['slug'],
+          required: true
+        },
+        {
+          model: User,
+          required: true,
+          attributes: ['id', 'email', 'username']
+        }
+      ],
+      where: {
+        id: commentId
+      }
+    });
+
+    const url = `${env.baseUrl}/api/articles/${comment.dataValues.Article.dataValues.slug}`;
+
+    const message = {
+      inAppMessage: '',
+      emailMessage: '',
+      emailButtonText: ''
+    };
+
+    message.inAppMessage = `The comment '${comment.dataValues.body.substring(substringInitialIndex,
+      substringFinalIndex)}...' has been ${operation}ed`;
+    message.emailMessage = `The comment '${comment.dataValues.body.substring(substringInitialIndex,
+      substringFinalIndex)}...' has been ${operation}ed. Click the button bellow to follow up`;
+    message.emailButtonText = 'Follow';
+
+    const notification = await sendNotification('comments',
+      'report',
+      comment.dataValues.User,
+      message,
+      url);
+
+    io.emit(`${operation}Comment`, notification);
+  } catch (error) {
+    return { errors: error };
+  }
+};

--- a/src/helpers/notifications/get.user.config.js
+++ b/src/helpers/notifications/get.user.config.js
@@ -1,0 +1,26 @@
+import models from '../../api/models';
+
+const { NotificationConfig } = models;
+
+/**
+ * A helper to get all notification configs of a user
+ * @param {integer} userId
+ * @returns {object} the config token
+ */
+export default async (userId) => {
+  const resultObject = {};
+  let userConfig;
+
+  try {
+    userConfig = await NotificationConfig.findOne({
+      where: { userId }
+    });
+
+    resultObject.success = true;
+    resultObject.config = JSON.parse(userConfig.dataValues.config);
+    return resultObject;
+  } catch (error) {
+    resultObject.success = false;
+    return resultObject;
+  }
+};

--- a/src/helpers/notifications/report.article.js
+++ b/src/helpers/notifications/report.article.js
@@ -1,0 +1,54 @@
+// eslint-disable-next-line import/no-cycle
+import { io } from '../../index';
+import env from '../../configs/environments';
+import models from '../../api/models';
+import sendNotification from './sender';
+
+const { Article, User } = models;
+
+export default async (articleSlug) => {
+  try {
+    const url = `${env.baseUrl}/api/articles/${articleSlug}`;
+
+    const message = {
+      inAppMessage: '',
+      emailMessage: '',
+      emailButtonText: ''
+    };
+
+    let notification = {};
+
+    const article = await Article.findOne({
+      attributes: ['title'],
+      include: {
+        model: User,
+        required: true,
+        attributes: ['id', 'email', 'username']
+      },
+      where: {
+        slug: articleSlug
+      }
+    });
+
+    const moderators = await User.findAll({
+      attributes: ['id', 'email', 'username'],
+      where: { role: 'moderator' }
+    });
+
+    message.inAppMessage = `The article ${article.title} has been reported`;
+    message.emailMessage = `The article ${
+      article.title
+    } has been reported. Click the button bellow to follow up`;
+    message.emailButtonText = 'Follow';
+
+    notification = await sendNotification('articles', 'report', article.User, message, url);
+    io.emit('reportArticle', notification);
+
+    return moderators.map(async (moderator) => {
+      notification = await sendNotification('articles', 'report', moderator, message, url);
+      io.emit('reportArticle', notification);
+    });
+  } catch (error) {
+    return { errors: error };
+  }
+};

--- a/src/helpers/notifications/report.comment.js
+++ b/src/helpers/notifications/report.comment.js
@@ -1,0 +1,70 @@
+// eslint-disable-next-line import/no-cycle
+import { io } from '../../index';
+import env from '../../configs/environments';
+import models from '../../api/models';
+import sendNotification from './sender';
+
+const { Article, User, Comment } = models;
+
+export default async (commentId) => {
+  try {
+    const substringInitialIndex = 0;
+    const substringFinalIndex = 20;
+    let notification = {};
+
+    const comment = await Comment.findOne({
+      attributes: ['body'],
+      include: [
+        {
+          model: Article,
+          attributes: ['slug'],
+          required: true
+        },
+        {
+          model: User,
+          required: true,
+          attributes: ['id', 'email', 'username']
+        }
+      ],
+      where: {
+        id: commentId
+      }
+    });
+
+    const url = `${env.baseUrl}/api/articles/${
+      comment.dataValues.Article.dataValues.slug
+    }/comments/${commentId}`;
+
+    const message = {
+      inAppMessage: '',
+      emailMessage: '',
+      emailButtonText: ''
+    };
+
+    const moderators = await User.findAll({
+      attributes: ['id', 'email', 'username'],
+      where: { role: 'moderator' }
+    });
+
+    message.inAppMessage = `The comment '${comment.dataValues.body.substring(substringInitialIndex,
+      substringFinalIndex)}...' has been reported`;
+    message.emailMessage = `The comment '${comment.dataValues.body.substring(substringInitialIndex,
+      substringFinalIndex)}...' has been reported. Click the button bellow to follow up`;
+    message.emailButtonText = 'Follow';
+
+    notification = await sendNotification('comments',
+      'report',
+      comment.dataValues.User,
+      message,
+      url);
+
+    io.emit('reportComment', notification);
+
+    return moderators.map(async (moderator) => {
+      notification = await sendNotification('articles', 'report', moderator, message, url);
+      io.emit('reportComment', notification);
+    });
+  } catch (error) {
+    return { errors: error };
+  }
+};

--- a/src/helpers/notifications/sender.js
+++ b/src/helpers/notifications/sender.js
@@ -1,0 +1,61 @@
+import models from '../../api/models';
+import getUserConfig from './get.user.config';
+import sendMail from '../Mailer';
+
+const { Notification } = models;
+
+/**
+ * @param {object} resource - The resource on which events are listened and notifications
+ * should be sent
+ * @param {object} action - The action whose event has been emitted
+ * @param {object} user
+ * @param {object} message
+ * @param {object} url
+ * @returns {object} notification
+ */
+export default async (resource, action, user, message, url) => {
+  // Initializing variables
+  let inAppNotification = {};
+  let emailNotification = {};
+
+  // getting the preferences of the user
+  const userConfig = await getUserConfig(user.dataValues.id);
+
+  // sending notifications
+  // In app
+  if (userConfig.success) {
+    const { inApp, email } = userConfig.config;
+
+    if (inApp[resource].show && inApp[resource].on.includes(action)) {
+      inAppNotification = await Notification.create({
+        userId: user.id,
+        message: message.inAppMessage,
+        url,
+        type: 'inApp'
+      });
+
+      inAppNotification = inAppNotification.get();
+    }
+
+    // Email
+    if (user.email && email[resource].show && email[resource].on.includes(action)) {
+      emailNotification = await Notification.create({
+        userId: user.id,
+        message: message.inAppMessage,
+        url,
+        type: 'email'
+      });
+
+      emailNotification = emailNotification.get();
+
+      await sendMail('Notification', `${resource} on ${action}`, user.email, 'notifications', {
+        message: message.emailMessage,
+        url,
+        userName: user.username,
+        buttonText: message.emailButtonText
+      });
+    }
+  } else process.stdout.write(`Oops! no configurations for ${user.dataValues.username}`);
+
+  return { inAppNotification, emailNotification };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,29 @@
 import express from 'express';
+import http from 'http';
+import socketIo from 'socket.io';
 import apiRouter from './api/routes/index';
 import docsRouter from './api/routes/docs';
 import homeRouter from './api/routes/home';
 import register from './middlewares/register.app';
 import env from './configs/environments';
+// eslint-disable-next-line import/no-cycle
+import initializeEvents from './helpers/event.listeners';
 
 const app = express();
+const server = http.createServer(app);
+const io = socketIo(server);
 
 // Register middleware
-register(app);
+register(app, io);
+app.server = server;
 
 app.use('/api', apiRouter);
 app.use('/docs', docsRouter);
 
 app.use('/', homeRouter);
 
-app.listen(env.appPort);
+app.server.listen(env.appPort, () => initializeEvents());
+
+export { io };
 
 export default app;

--- a/src/middlewares/check.update.notification.js
+++ b/src/middlewares/check.update.notification.js
@@ -1,0 +1,44 @@
+import models from '../api/models';
+import statusCode from '../helpers/constants/status.codes';
+import sendError from '../helpers/error.sender';
+
+const { Notification } = models;
+
+/**
+ * A middleware to check if a notification exists in the database.
+ *
+ * @author Prémices
+ * @static
+ * @param {object} req the request
+ * @param {object} res the response to be sent
+ * @param { object } next the next route controller to be called
+ * @returns {Object} req, next
+ */
+export default async (req, res, next) => {
+  // Initializing variables
+  const { id } = req.params;
+  const requestType = req.url.includes('unseen') ? 'unseen' : 'seen';
+  const {
+    user: { id: userId }
+  } = req.user;
+
+  try {
+    const result = await Notification.findOne({
+      where: {
+        id,
+        userId
+      }
+    });
+
+    if (result.dataValues.status === requestType) {
+      return sendError(statusCode.BAD_REQUEST,
+        res,
+        'id',
+        `Notification with id ${id} has already status with value: ${requestType}`);
+    }
+    req.comment = result.dataValues;
+    return next();
+  } catch (error) {
+    return sendError(statusCode.NOT_FOUND, res, 'id', `Notification with id ${id} is not found`);
+  }
+};

--- a/src/middlewares/register.app.js
+++ b/src/middlewares/register.app.js
@@ -1,5 +1,5 @@
 /**
- * Resgister midllemware file
+ * Register middleware file
  * @name register
  */
 import bodyParser from 'body-parser';
@@ -18,9 +18,12 @@ dotenv.config();
  * @returns {Boolean} true
  */
 
-export default (app) => {
+export default (app, io) => {
   app
-  // Parse req object and make data available on req.body
+    .use((req, res, next) => {
+      req.io = io;
+      next();
+    })
     .use(bodyParser.json())
     .use(bodyParser.urlencoded({ extended: true }))
     .use(session({
@@ -31,5 +34,7 @@ export default (app) => {
     .use(passport.initialize())
     .use(cors()) // Allow cross origin requests
     .use(logger('dev')); // Logging http requests
+
+  io.on('connection', socket => socket.emit('welcome', 'Welcome to authors heaven'));
   return true;
 };

--- a/tests/article.comments.js
+++ b/tests/article.comments.js
@@ -94,6 +94,26 @@ describe('Article comments', async () => {
         done();
       });
   });
+  it('should get a single comment of an article', (done) => {
+    chai
+      .request(server)
+      .get('/api/articles/How-to-create-sequalize-seeds/comments/1')
+      .set('authorization', `${testUserToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+  it('should return an error when the comment does not exist', (done) => {
+    chai
+      .request(server)
+      .get('/api/articles/How-to-create-sequalize-seeds/comments/56424224544')
+      .set('authorization', `${testUserToken}`)
+      .end((err, res) => {
+        res.should.have.status(status.NOT_FOUND);
+        done();
+      });
+  });
   it('should update a comment', (done) => {
     chai
       .request(server)

--- a/tests/notifications.test.js
+++ b/tests/notifications.test.js
@@ -1,0 +1,217 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../src/index';
+import status from '../src/helpers/constants/status.codes';
+import blockArticle from '../src/helpers/notifications/block.article';
+import blockComment from '../src/helpers/notifications/block.comment';
+
+chai.use(chaiHttp);
+chai.should();
+
+// The test user
+const user1 = {
+  email: 'alain1@gmail.com',
+  password: 'password23423'
+};
+
+const user2 = {
+  email: 'alain2@gmail.com',
+  password: 'password23423'
+};
+
+const notificationsConfig = {
+  inApp: {
+    articles: {
+      show: false,
+      on: ['report', 'block']
+    },
+    comments: {
+      show: true,
+      on: ['report', 'block']
+    }
+  },
+  email: {
+    articles: {
+      show: false,
+      on: ['report', 'block']
+    },
+    comments: {
+      show: true,
+      on: ['report', 'block']
+    }
+  }
+};
+
+let testUserToken1;
+let testUserToken2;
+
+describe('Notifications', () => {
+  before((done) => {
+    chai
+      .request(server)
+      .post('/api/users/login')
+      .send(user1)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        res.body.should.be.an('Object');
+        testUserToken1 = res.body.user.token;
+      });
+
+    chai
+      .request(server)
+      .post('/api/users/login')
+      .send(user2)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        res.body.should.be.an('Object');
+        testUserToken2 = res.body.user.token;
+        done();
+      });
+  });
+
+  it('should update the configurations of the user', (done) => {
+    chai
+      .request(server)
+      .patch('/api/notifications/configuration')
+      .send(notificationsConfig)
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should get the configurations of the user', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications/configuration')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should get all notifications sent for all previous events', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should return an error when there is not notification', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications')
+      .set('authorization', `${testUserToken2}`)
+      .end((err, res) => {
+        res.should.have.status(status.NOT_FOUND);
+        done();
+      });
+  });
+
+  it('should update a single notification', (done) => {
+    chai
+      .request(server)
+      .patch('/api/notifications/1/seen')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should not update a single notification twice with the same status', (done) => {
+    chai
+      .request(server)
+      .patch('/api/notifications/1/seen')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.BAD_REQUEST);
+        done();
+      });
+  });
+
+  it('should raise an error when the notification is not found', (done) => {
+    chai
+      .request(server)
+      .patch('/api/notifications/100/seen')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.NOT_FOUND);
+        done();
+      });
+  });
+
+  it('should get all seen notifications of a user', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications/seen')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should not get all seen notifications of a deferent user', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications/seen')
+      .set('authorization', `${testUserToken2}`)
+      .end((err, res) => {
+        res.should.have.status(status.NOT_FOUND);
+        done();
+      });
+  });
+
+  it('should get all unseen notifications of a user', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications/unseen')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should update a single notification with a different status', (done) => {
+    chai
+      .request(server)
+      .patch('/api/notifications/1/unseen')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+
+  it('should unsubscribe for emails', (done) => {
+    chai
+      .request(server)
+      .get('/api/notifications/configuration/unsubscribe/email')
+      .set('authorization', `${testUserToken1}`)
+      .end((err, res) => {
+        res.should.have.status(status.OK);
+        done();
+      });
+  });
+});
+
+describe('Notification helpers', () => {
+  describe('Block article', () => {
+    it('Should execute without params', () => {
+      blockArticle();
+    });
+  });
+  describe('Block comment', () => {
+    it('Should execute without params', () => {
+      blockComment();
+    });
+  });
+});


### PR DESCRIPTION
#### [Use Case Document](https://docs.google.com/document/d/1C5xFY-Uy1gHs2TQ2-KC3gC_RnK0DXDgWY0w2aBW75cI/edit)

#### What does this PR do?
Have notification support for users

#### Description of Task to be completed?
Have the following endpoints working 
* `PATCH api/notifications/configuration` Update the configurations of a user
* `GET api/notifications/configuration` Get the configurations of a user
* `GET api/notifications` Get all notifications of a user
* `GET api/notifications/seen` Get all seen notifications of a user
* `GET api/notifications/unseen` Get all unseen notifications of a user
*  `PATCH api/notifications/:id/seen` Set a single notification as `seen`
* `PATCH api/notifications/:id/unseen` Set a single notification as `unseen`
* `PATCH api/notifications/configuration/unsubscribe/email` unsubscribe email notifications for a specific user

#### How should this be manually tested?
> a) Generating notifications

After cloning the repo and installing the app: 
* Report an article (Normal user)
* Block an article (admin)
* Report a comment on an article (Normal user)
* Block a comment on an article (admin)

> b) Subscriptions

After receiving a notification email:
* Click on `unsubscribe` to unsubscribe for the email notifications
After receiving an `inApp` notification
* Click on `snooze` to snooze notifications

#### Any background context you want to provide?
When a user has signed up - by default - in app and email notifications configs are set up.
There are event listeners on `block` and on `report` of both articles and comments.
