### PR TITLE
enable the author to fetch a single drafted article

### DIFF
--- a/src/api/controllers/articleController.js
+++ b/src/api/controllers/articleController.js
@@ -234,6 +234,7 @@ export default class ArticleController {
       category: category || req.Existing.category,
       coverImage: coverImage || req.Existing.coverImage
     };
+
     await ArticleTag.destroy({ where: { articleId: req.article.id } });
     const readTime = generateReadtime(updateContent.body);
     updateContent.readTime = readTime;
@@ -280,6 +281,33 @@ export default class ArticleController {
         offset,
         limit),
       data: articles.rows
+    });
+  }
+
+  /**
+   * This function gets a single drafted article
+   *
+   * @static
+   * @param {Object} req the request
+   * @param {Object} res the response to be sent
+   * @memberof Articles
+   * @returns {Object} res
+   */
+  static async getDraftedArticle(req, res) {
+    const { id } = req.user.user;
+    const { slug } = req.params;
+
+    const article = await Article.findOne({
+      include: articleInclude,
+      where: {
+        slug,
+        status: 'draft',
+        author: id
+      }
+    });
+    res.status(statusCodes.OK).json({
+      status: statusCodes.OK,
+      article
     });
   }
 }

--- a/src/api/routes/articleRouter.js
+++ b/src/api/routes/articleRouter.js
@@ -187,4 +187,10 @@ articleRouter.post('/:slug/comments/:id/report',
   validateInputs('reportComment', ['commentReason']),
   reportCommentController.reportComment);
 
+articleRouter.get('/drafts/:slug',
+  checkValidToken,
+  checkArticle.getArticle,
+  checkArticleOwner.checkOwner,
+  articleController.getDraftedArticle);
+
 export default articleRouter;

--- a/src/helpers/constants/validation.schemas.js
+++ b/src/helpers/constants/validation.schemas.js
@@ -122,7 +122,8 @@ export default {
     category: Joi.number().integer(),
     tags: Joi.array()
       .items(string.alphanum())
-      .required()
+      .required(),
+    coverImage: Joi.string()
   }),
   highlight: Joi.object().keys({
     startIndex: Joi.number()

--- a/tests/updateArticle.test.js
+++ b/tests/updateArticle.test.js
@@ -62,7 +62,8 @@ describe('testing the middlewares before reaching the update article controller'
       .set('authorization', UserToken)
       .send({
         body: 'how did the classical Latin become',
-        tags: ['Laravel', 'php', 'IOT', 'iot2']
+        tags: ['Laravel', 'php', 'IOT', 'iot2'],
+        coverImage: 'http://localhost/jpeg'
       })
       .end((err, res) => {
         expect(res.status).eql(status.ACCESS_DENIED);
@@ -121,7 +122,8 @@ describe('testing for the article update controller', () => {
       .set('authorization', UserToken)
       .send({
         body: '',
-        tags: ['Laravel', 'php', 'IOT', 'iot2']
+        tags: ['Laravel', 'php', 'IOT', 'iot2'],
+        coverImage: 'http://localhost:3000/ver.jpg'
       })
       .end((err, res) => {
         expect(res.status).eql(status.OK);


### PR DESCRIPTION
#### What does this PR do?
* It enables the author to fetch a single drafted article.
#### Description of Task to be completed?
 * Create end-point for fetching a single drafted article.
#### How should this be manually tested?
* Clone the repo to the local machine.
* Run ``npm install``   to install the dependencies.
* Set up the   ``.env`` as instructed by the   ``.env-example``
* Run  ``npm setup:dev``.
*Run ``npm start``.
* Send a GET request to ``/api/articles/drafts/:slug``.
#### What are the relevant pivotal tracker stories?
#[168242065](https://www.pivotaltracker.com/story/show/168242065)